### PR TITLE
 feat(import): 实现 VPM 包路径搜索与包名缩写展开

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -382,6 +382,9 @@ void print_ast(ASTNode* node, int indent);
 int get_array_length(ASTNode* node);
 // Inline imports: parse modules and inline their `pub` functions into the AST
 void inline_imports(ASTNode* node);
+// Resolve import path with VPM search priority.
+// Returns 1 on success and writes resolved path to 'out', 0 on failure.
+int vix_resolve_import_path(const char* current_file, const char* module_path, char* out, size_t out_size);
 
 #ifdef __cplusplus
 }

--- a/include/compat.h
+++ b/include/compat.h
@@ -64,6 +64,10 @@ static inline int vix_is_stderr_tty(void) {
 #endif
 }
 
+static inline const char* vix_getenv(const char* name) {
+    return getenv(name);
+}
+
 static inline int vix_setenv(const char* name, const char* value, int overwrite) {
     if (!name || !value) return -1;
 #ifdef _WIN32

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -100,17 +100,26 @@ static int canonicalize_existing_path(const char* path, char* out, size_t out_si
     return 1;
 }
 
-static int resolve_import_path(const char* current_file, const char* module_path, char* out, size_t out_size) {
+static int try_resolve_import_path(const char* base_dir, const char* module_path, char* out, size_t out_size) {
+    char candidate[1024];
+    snprintf(candidate, sizeof(candidate), "%s/%s", base_dir, module_path);
+    if (vix_file_exists(candidate)) {
+        return canonicalize_existing_path(candidate, out, out_size);
+    }
+    return 0;
+}
+
+int vix_resolve_import_path(const char* current_file, const char* module_path, char* out, size_t out_size) {
     if (!module_path || !out || out_size == 0) return 0;
 
-    char candidate[1024];
+    // Priority 1: relative to current file's directory (existing behavior)
     if (module_path[0] == '/') {
-        strncpy(candidate, module_path, sizeof(candidate) - 1);
-        candidate[sizeof(candidate) - 1] = '\0';
-    } else {
-        const char* current = current_file ? current_file : ".";
+        if (vix_file_exists(module_path)) {
+            return canonicalize_existing_path(module_path, out, out_size);
+        }
+    } else if (current_file) {
         char dir_path[1024];
-        strncpy(dir_path, current, sizeof(dir_path) - 1);
+        strncpy(dir_path, current_file, sizeof(dir_path) - 1);
         dir_path[sizeof(dir_path) - 1] = '\0';
         char* last_slash = strrchr(dir_path, '/');
         if (last_slash) {
@@ -118,10 +127,37 @@ static int resolve_import_path(const char* current_file, const char* module_path
         } else {
             strcpy(dir_path, "./");
         }
+        char candidate[1024];
         snprintf(candidate, sizeof(candidate), "%s%s", dir_path, module_path);
+        if (vix_file_exists(candidate)) {
+            return canonicalize_existing_path(candidate, out, out_size);
+        }
     }
 
-    return canonicalize_existing_path(candidate, out, out_size);
+    // Priority 2: $VIX_HOME/std/
+    const char* vix_home = vix_getenv("VIX_HOME");
+    if (vix_home && vix_home[0] != '\0') {
+        char base[1024];
+        snprintf(base, sizeof(base), "%s/std", vix_home);
+        if (try_resolve_import_path(base, module_path, out, out_size)) return 1;
+    }
+
+    // Priority 3: .vix/libs/ (project-local packages)
+    if (try_resolve_import_path(".vix/libs", module_path, out, out_size)) return 1;
+
+    // Priority 4: $VIX_HOME/libs/
+    if (vix_home && vix_home[0] != '\0') {
+        char base[1024];
+        snprintf(base, sizeof(base), "%s/libs", vix_home);
+        if (try_resolve_import_path(base, module_path, out, out_size)) return 1;
+    }
+
+    return 0;
+}
+
+// Deprecated: use vix_resolve_import_path instead
+static int resolve_import_path(const char* current_file, const char* module_path, char* out, size_t out_size) {
+    return vix_resolve_import_path(current_file, module_path, out, out_size);
 }
 
 static int import_cache_contains(const char* canonical_path) {

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -100,6 +100,58 @@ static int canonicalize_existing_path(const char* path, char* out, size_t out_si
     return 1;
 }
 
+static int vix_expand_package_name(const char* module_path, char* out, size_t out_size) {
+    if (!module_path || !out || out_size == 0) return 0;
+    if (strchr(module_path, '/') != NULL) return 0;
+
+    char registry[256] = "github.com";
+    char user[256] = "";
+    char repo[256] = "";
+    const char* p = module_path;
+
+    if (p[0] == '@') {
+        strncpy(registry, "gitee.com", sizeof(registry) - 1);
+        registry[sizeof(registry) - 1] = '\0';
+        p++;
+    } else {
+        const char* colon = strchr(p, ':');
+        if (colon) {
+            size_t reg_len = colon - p;
+            if (reg_len > 0 && reg_len < sizeof(registry)) {
+                strncpy(registry, p, reg_len);
+                registry[reg_len] = '\0';
+                if (strchr(registry, '.') == NULL) {
+                    size_t avail = sizeof(registry) - strlen(registry) - 1;
+                    strncat(registry, ".com", avail);
+                }
+            }
+            p = colon + 1;
+        }
+    }
+
+    const char* dot = strchr(p, '.');
+    if (dot) {
+        size_t user_len = dot - p;
+        if (user_len > 0 && user_len < sizeof(user)) {
+            strncpy(user, p, user_len);
+            user[user_len] = '\0';
+            strncpy(repo, dot + 1, sizeof(repo) - 1);
+            repo[sizeof(repo) - 1] = '\0';
+        } else {
+            return 0;
+        }
+    } else {
+        strncpy(user, "vixlang", sizeof(user) - 1);
+        user[sizeof(user) - 1] = '\0';
+        int n = snprintf(repo, sizeof(repo), "vlib-%s", p);
+        if (n < 0 || (size_t)n >= sizeof(repo)) return 0;
+    }
+
+    int n = snprintf(out, out_size, "%s/%s/%s", registry, user, repo);
+    if (n < 0 || (size_t)n >= out_size) return 0;
+    return 1;
+}
+
 static int try_resolve_import_path(const char* base_dir, const char* module_path, char* out, size_t out_size) {
     char candidate[1024];
     snprintf(candidate, sizeof(candidate), "%s/%s", base_dir, module_path);
@@ -134,22 +186,45 @@ int vix_resolve_import_path(const char* current_file, const char* module_path, c
         }
     }
 
-    // Priority 2: $VIX_HOME/std/
-    const char* vix_home = vix_getenv("VIX_HOME");
-    if (vix_home && vix_home[0] != '\0') {
-        char base[1024];
-        snprintf(base, sizeof(base), "%s/std", vix_home);
-        if (try_resolve_import_path(base, module_path, out, out_size)) return 1;
-    }
+    // Priority 2: package name expansion (for bare names without '/')
+    if (strchr(module_path, '/') == NULL) {
+        char expanded[1024];
+        if (vix_expand_package_name(module_path, expanded, sizeof(expanded))) {
+            const char* vix_home = vix_getenv("VIX_HOME");
+            char lib_path[1024];
 
-    // Priority 3: .vix/libs/ (project-local packages)
-    if (try_resolve_import_path(".vix/libs", module_path, out, out_size)) return 1;
+            snprintf(lib_path, sizeof(lib_path), ".vix/libs/%s/main.vix", expanded);
+            if (vix_file_exists(lib_path)) {
+                return canonicalize_existing_path(lib_path, out, out_size);
+            }
 
-    // Priority 4: $VIX_HOME/libs/
-    if (vix_home && vix_home[0] != '\0') {
-        char base[1024];
-        snprintf(base, sizeof(base), "%s/libs", vix_home);
-        if (try_resolve_import_path(base, module_path, out, out_size)) return 1;
+            if (vix_home && vix_home[0] != '\0') {
+                snprintf(lib_path, sizeof(lib_path), "%s/libs/%s/main.vix", vix_home, expanded);
+                if (vix_file_exists(lib_path)) {
+                    return canonicalize_existing_path(lib_path, out, out_size);
+                }
+
+                // Bare name standard library fallback
+                snprintf(lib_path, sizeof(lib_path), "%s/std/%s", vix_home, module_path);
+                if (vix_file_exists(lib_path)) {
+                    return canonicalize_existing_path(lib_path, out, out_size);
+                }
+            }
+        }
+    } else {
+        // Priority 3: path-style import (contains '/'), backward-compatible direct search
+        const char* vix_home = vix_getenv("VIX_HOME");
+        if (vix_home && vix_home[0] != '\0') {
+            char base[1024];
+            snprintf(base, sizeof(base), "%s/std", vix_home);
+            if (try_resolve_import_path(base, module_path, out, out_size)) return 1;
+        }
+        if (try_resolve_import_path(".vix/libs", module_path, out, out_size)) return 1;
+        if (vix_home && vix_home[0] != '\0') {
+            char base[1024];
+            snprintf(base, sizeof(base), "%s/libs", vix_home);
+            if (try_resolve_import_path(base, module_path, out, out_size)) return 1;
+        }
     }
 
     return 0;


### PR DESCRIPTION
## 概述

为 Vix 编译器实现 VPM（Vix Package Manager）的 import 路径解析系统。当用户在代码中写 `import "game"` 时，编译器现在能够自动将缩写包名展开为完整路径，并在多个预设目录中分级搜索。

## 背景

原来的 `resolve_import_path()` 只支持相对路径解析（`import "./foo.vix"`），没有任何包管理能力。用户无法通过简短的名字引用第三方包或标准库。

## 改动详情

### 1. VPM 分级搜索（对应 518e747）

将原有的 `resolve_import_path()` 重构为 `vix_resolve_import_path()`，引入四级搜索优先级：

| 优先级 | 搜索路径 | 说明 |
|--------|----------|------|
| Priority 1 | 相对当前文件目录 | 保留原有行为，`import "src/lib.vix"` 相对于当前 `.vix` 文件位置查找 |
| Priority 2 | `$VIX_HOME/std/{path}` | 标准库路径，如 `import "io"` 会搜索 `$VIX_HOME/std/io` |
| Priority 3 | `.vix/libs/{path}` | 项目本地包，`very add` 安装的包存放于此 |
| Priority 4 | `$VIX_HOME/libs/{path}` | 全局安装的包 |

同时新增的辅助设施：

- `vix_getenv()`（`compat.h`）— 跨平台环境变量读取包装
- `try_resolve_import_path()`（`ast.c`）— 在指定基础目录下拼接并检查文件存在性
- `vix_resolve_import_path()`（`ast.h`）— 公开接口，供 `semantic.c` 调用
- 旧的 `resolve_import_path()` 保留为废弃包装器，向后兼容

### 2. 包名缩写展开（对应 ce51abd 的 ast.c 部分）

新增 `vix_expand_package_name()` 静态函数，按照 VPM 约定将缩写包名展开为 `registry/org/repo` 格式的三段式路径：

| 输入格式 | 判定方式 | 展开结果 | 示例 |
|----------|----------|----------|------|
| `game` | 裸名（无 `.` 无 `:` 无 `@`） | `github.com/vixlang/vlib-{name}` | `game` → `github.com/vixlang/vlib-game` |
| `fexcode.vnet` | 包含 `.`，无 `:` | `github.com/{user}.{repo}` | `fexcode.vnet` → `github.com/fexcode/vnet` |
| `gitee.com:fexcode.vnet` | 包含 `:` | `{domain}/{user}/{repo}` | `gitee.com:fexcode.vnet` → `gitee.com/fexcode/vnet` |
| `gitee:fexcode.vnet` | 含 `:` 且 registry 无 `.` | 自动补 `.com` | `gitee:fexcode.vnet` → `gitee.com/fexcode/vnet` |
| `@fexcode.vnet` | 以 `@` 开头 | `registry = gitee.com` | `@fexcode.vnet` → `gitee.com/fexcode/vnet` |

展开后搜索逻辑（替换原有的 Priority 2–4）：

搜索顺序为：
1. `.vix/libs/{expanded}/main.vix`
2. `$VIX_HOME/libs/{expanded}/main.vix`
3. 裸名时回退 `$VIX_HOME/std/{name}`

路径式 import（`module_path` 含 `/`，如 `import "std/io"` 或 `import "../foo.vix"`）走向后兼容分支，直接搜索各目录。

## 涉及文件

| 文件 | 变更 |
|------|------|
| `include/ast.h` | +3 行：声明 `vix_resolve_import_path` 公共接口 |
| `include/compat.h` | +4 行：新增 `vix_getenv` 跨平台环境变量读取包装 |
| `src/ast/ast.c` | +125/-7 行：重构 import 解析，新增包名展开函数 |