### PR TITLE
fix(codegen): 修复泛型实例化中原始类型被错误映射为指针

### DIFF
--- a/src/compiler/Stmts.cpp
+++ b/src/compiler/Stmts.cpp
@@ -1093,6 +1093,19 @@ LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitAssign(ASTNode* node) {
             if (!inferredLLVM && node->data.assign.right && node->data.assign.right->inferred_type) {
                 inferredLLVM = getLLVMTypeFromTypeInfo(node->data.assign.right->inferred_type);
             }
+            // Check declared type against active generic type bindings:
+            // when a generic type param T resolves to a concrete type (e.g. i32),
+            // the inferred_type may still be TYPEINFO_VAR which maps to ptr.
+            // Use the concrete binding type instead.
+            if (node->data.assign.declared_type &&
+                node->data.assign.declared_type->type == AST_IDENTIFIER &&
+                node->data.assign.declared_type->data.identifier.name) {
+                std::string typeName(node->data.assign.declared_type->data.identifier.name);
+                auto gbt = activeGenericTypeBindings.find(typeName);
+                if (gbt != activeGenericTypeBindings.end() && gbt->second) {
+                    inferredLLVM = gbt->second;
+                }
+            }
             if (inferredLLVM && inferredLLVM != rightVal.value->getType()) {
                 // Convert the value to the inferred type (e.g., ptr -> i32 for ADT payloads)
                 if (inferredLLVM->isIntegerTy() && rightVal.value->getType()->isPointerTy()) {


### PR DESCRIPTION
修复泛型实例化中原始类型参数被错误映射为指针的问题

Bug 描述

当泛型函数中的类型参数 `T` 实例化为 `i32`、`f64` 等原始类型时，`visitAssign` 中 `getLLVMTypeFromTypeInfo(TYPEINFO_VAR)` 错误地返回了 `ptr`，导致：

- 泛型局部变量被分配为 `ptr` 而非 `i32`
- 整数值通过 `inttoptr` 被强制转为指针
- 比较操作使用 `icmp ugt ptr`（指针语义）而非 `icmp sgt i32`
- 返回时解引用非法地址 `0x1` 导致段错误/无输出

修复

在 `src/compiler/Stmts.cpp` 的 `visitAssign` 中，当 `declared_type` 匹配 `activeGenericTypeBindings` 中的泛型绑定时，使用绑定的具体 LLVM Type 覆盖错误推断的类型。

涉及文件

- `src/compiler/Stmts.cpp` — 增加 11 行泛型绑定类型检查