### PR TITLE
fix(codegen): 修复泛型实例化中类型参数未传递到被调用函数的问题

### DIFF
--- a/src/compiler/Codegen.cpp
+++ b/src/compiler/Codegen.cpp
@@ -155,6 +155,22 @@ std::string LLVMCodeGenerator::typeNodeToMangleToken(ASTNode* typeNode) const {
     }
 }
 
+std::string LLVMCodeGenerator::llvmTypeToToken(Type* type) {
+    if (!type) return "void";
+    if (type->isIntegerTy(32)) return "i32";
+    if (type->isIntegerTy(64)) return "i64";
+    if (type->isIntegerTy(8)) return "i8";
+    if (type->isIntegerTy(1)) return "bool";
+    if (type->isFloatTy()) return "f32";
+    if (type->isDoubleTy()) return "f64";
+    if (type->isPointerTy()) return "ptr";
+    if (type->isStructTy()) {
+        auto* st = cast<StructType>(type);
+        if (st->hasName()) return LLVMCodeGenerator::sanitizeTypeToken(st->getName().str());
+    }
+    return "unk";
+}
+
 std::string LLVMCodeGenerator::mangleGenericFunctionName(const std::string& baseName, ASTNode* typeArgs) const {
     std::string name = baseName;
     name += "__g";
@@ -173,6 +189,25 @@ bool LLVMCodeGenerator::bindGenericTypeArgs(ASTNode* fnNode, ASTNode* typeArgs, 
     ASTNode* genericParams = fnNode->data.function.generic_params;
     if (!genericParams || genericParams->type != AST_EXPRESSION_LIST) return false;
     if (!typeArgs) {
+        // When called without explicit type args (e.g., from generic context),
+        // inherit bindings from activeGenericTypeBindings.
+        // If a generic param name matches a key in activeGenericTypeBindings, use it.
+        // Otherwise, default to i32.
+        if (!activeGenericTypeBindings.empty()) {
+            int paramCount = genericParams->data.expression_list.expression_count;
+            for (int i = 0; i < paramCount; i++) {
+                ASTNode* p = genericParams->data.expression_list.expressions[i];
+                if (!p || p->type != AST_IDENTIFIER || !p->data.identifier.name) return false;
+                std::string paramName(p->data.identifier.name);
+                auto it = activeGenericTypeBindings.find(paramName);
+                if (it != activeGenericTypeBindings.end() && it->second) {
+                    outBindings[paramName] = it->second;
+                } else {
+                    outBindings[paramName] = Type::getInt32Ty(context);
+                }
+            }
+            return true;
+        }
         int paramCount = genericParams->data.expression_list.expression_count;
         for (int i = 0; i < paramCount; i++) {
             ASTNode* p = genericParams->data.expression_list.expressions[i];
@@ -199,15 +234,62 @@ Function* LLVMCodeGenerator::instantiateGenericFunction(const std::string& baseN
     auto fit = genericFunctionTemplates.find(baseName);
     if (fit == genericFunctionTemplates.end()) return nullptr;
 
-    std::string mangledName = mangleGenericFunctionName(baseName, typeArgs);
-    if (Function* existing = module->getFunction(mangledName)) return existing;
-
+    // Step 1: Compute concrete type bindings first (before mangling).
+    // This ensures that generic param references like `T` are resolved
+    // to concrete types (e.g. i32) so the mangled name uses the concrete
+    // type token, not the generic param name.
     std::map<std::string, Type*> bindings;
-    if (!bindGenericTypeArgs(fit->second, typeArgs, bindings)) {
-        llvm::errs() << "Error: Failed to bind generic type arguments for function '" << baseName << "'\n";
-        return nullptr;
+    if (typeArgs) {
+        // Explicit type args: resolve through genericTypeBindings if needed
+        bindGenericTypeArgs(fit->second, typeArgs, bindings);
+    } else if (!activeGenericTypeBindings.empty()) {
+        // No explicit type args but we're in a generic context.
+        // Inherit bindings from the active context (caller's generic params).
+        ASTNode* genericParams = fit->second->data.function.generic_params;
+        if (genericParams && genericParams->type == AST_EXPRESSION_LIST) {
+            for (int i = 0; i < genericParams->data.expression_list.expression_count; i++) {
+                ASTNode* p = genericParams->data.expression_list.expressions[i];
+                if (p && p->type == AST_IDENTIFIER && p->data.identifier.name) {
+                    std::string paramName(p->data.identifier.name);
+                    auto it = activeGenericTypeBindings.find(paramName);
+                    if (it != activeGenericTypeBindings.end() && it->second) {
+                        bindings[paramName] = it->second;
+                    }
+                }
+            }
+        }
     }
 
+    // Fallback: use bindGenericTypeArgs with nullptr (defaults or inherits)
+    if (bindings.empty()) {
+        if (!bindGenericTypeArgs(fit->second, typeArgs, bindings)) {
+            llvm::errs() << "Error: Failed to bind generic type arguments for function '" << baseName << "'\n";
+            return nullptr;
+        }
+    }
+
+    // Step 2: Compute mangled name from concrete type bindings
+    std::string mangledName = baseName + "__g";
+    ASTNode* genericParams = fit->second->data.function.generic_params;
+    if (genericParams && genericParams->type == AST_EXPRESSION_LIST) {
+        for (int i = 0; i < genericParams->data.expression_list.expression_count; i++) {
+            ASTNode* p = genericParams->data.expression_list.expressions[i];
+            if (p && p->type == AST_IDENTIFIER && p->data.identifier.name) {
+                std::string paramName(p->data.identifier.name);
+                auto it = bindings.find(paramName);
+                mangledName += "_";
+                if (it != bindings.end() && it->second) {
+                    mangledName += llvmTypeToToken(it->second);
+                } else {
+                    mangledName += sanitizeTypeToken(paramName);
+                }
+            }
+        }
+    }
+
+    if (Function* existing = module->getFunction(mangledName)) return existing;
+
+    // Step 3: Generate function body with bindings
     auto oldBindings = activeGenericTypeBindings;
     activeGenericTypeBindings = bindings;
     typeHelper.setGenericTypeBindings(activeGenericTypeBindings);
@@ -327,18 +409,43 @@ Type* LLVMCodeGenerator::getInferredLLVMType(ASTNode* node) {
 Type* LLVMCodeGenerator::getInferredArrayElementType(ASTNode* node) {
     if (!node || !node->inferred_type) return nullptr;
     const TypeInfo* info = node->inferred_type;
-    if (info->kind == TYPEINFO_ARRAY || info->kind == TYPEINFO_FIXED_ARRAY)
-        return getLLVMTypeFromTypeInfo(info->element);
+    if (info->kind == TYPEINFO_ARRAY || info->kind == TYPEINFO_FIXED_ARRAY) {
+        Type* elemType = getLLVMTypeFromTypeInfo(info->element);
+        // When the element type is a generic type param (TYPEINFO_VAR),
+        // getLLVMTypeFromTypeInfo returns ptr. Check activeGenericTypeBindings
+        // for the concrete type.
+        if (elemType && elemType->isPointerTy() && info->element->kind == TYPEINFO_VAR) {
+            std::string typeName(info->element->name ? info->element->name : "");
+            if (!typeName.empty()) {
+                auto gbt = activeGenericTypeBindings.find(typeName);
+                if (gbt != activeGenericTypeBindings.end() && gbt->second) {
+                    elemType = gbt->second;
+                }
+            }
+        }
+        return elemType;
+    }
     return nullptr;
 }
 
 Type* LLVMCodeGenerator::getInferredPointerElementType(ASTNode* node) {
     if (!node || !node->inferred_type) return nullptr;
+    Type* result = nullptr;
     if (node->inferred_type->kind == TYPEINFO_PTR)
-        return getLLVMTypeFromTypeInfo(node->inferred_type->element);
+        result = getLLVMTypeFromTypeInfo(node->inferred_type->element);
     if (node->inferred_type->kind == TYPEINFO_ARRAY || node->inferred_type->kind == TYPEINFO_FIXED_ARRAY)
-        return getLLVMTypeFromTypeInfo(node->inferred_type->element);
-    return nullptr;
+        result = getLLVMTypeFromTypeInfo(node->inferred_type->element);
+    if (result && result->isPointerTy() && node->inferred_type->element &&
+        node->inferred_type->element->kind == TYPEINFO_VAR) {
+        std::string typeName(node->inferred_type->element->name ? node->inferred_type->element->name : "");
+        if (!typeName.empty()) {
+            auto gbt = activeGenericTypeBindings.find(typeName);
+            if (gbt != activeGenericTypeBindings.end() && gbt->second) {
+                result = gbt->second;
+            }
+        }
+    }
+    return result;
 }
 
 AllocaInst* LLVMCodeGenerator::findVariableInMain(const std::string& name) {

--- a/src/compiler/Codegen.h
+++ b/src/compiler/Codegen.h
@@ -109,6 +109,7 @@ private:
     std::string mangleGenericFunctionName(const std::string& baseName, ASTNode* typeArgs) const;
     bool bindGenericTypeArgs(ASTNode* fnNode, ASTNode* typeArgs, std::map<std::string, llvm::Type*>& outBindings);
     llvm::Function* instantiateGenericFunction(const std::string& baseName, ASTNode* typeArgs);
+    static std::string llvmTypeToToken(llvm::Type* type);
 
     // Insert point / module helpers
     bool ensureValidInsertPoint();

--- a/src/compiler/Funcs.cpp
+++ b/src/compiler/Funcs.cpp
@@ -735,6 +735,17 @@ using namespace llvm;
                     }
                 }
 
+                // Fallback: if elemType is still ptr but the arg has a concrete
+                // non-pointer type, use the arg's type. This handles generic
+                // type params like T=i32 where TYPEINFO_VAR maps to ptr.
+                if (elemType && elemType->isPointerTy() && argRes.value &&
+                    argRes.value->getType() && !argRes.value->getType()->isPointerTy() &&
+                    !argRes.value->getType()->isStructTy() &&
+                    !(argRes.structType && (argRes.value->getType()->isStructTy() ||
+                       (argRes.value->getType()->isPointerTy() && argRes.type == ValueType::POINTER)))) {
+                    elemType = argRes.value->getType();
+                }
+
                 Type* storageElemType = elemType;
                 ValueType elemVT = typeHelper.getValueTypeFromType(elemType);
                 Value* argCast = nullptr;
@@ -1098,7 +1109,7 @@ using namespace llvm;
                 llvm::errs() << "Error: Failed to instantiate generic function '" << calleeName << "'\n";
                 return VisitResult();
             }
-            calleeName = mangleGenericFunctionName(calleeName, node->data.call.type_args);
+            calleeName = instFn->getName().str();
         }
 
         Function* callee = module->getFunction(calleeName);
@@ -1107,8 +1118,8 @@ using namespace llvm;
             if (fit != genericFunctionTemplates.end()) {
                 Function* instFn = instantiateGenericFunction(calleeName, nullptr);
                 if (instFn) {
-                    calleeName = mangleGenericFunctionName(calleeName, nullptr);
-                    callee = module->getFunction(calleeName);
+                    callee = instFn;
+                    calleeName = instFn->getName().str();
                 }
             }
         }

--- a/src/compiler/Stmts.cpp
+++ b/src/compiler/Stmts.cpp
@@ -1106,6 +1106,16 @@ LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitAssign(ASTNode* node) {
                     inferredLLVM = gbt->second;
                 }
             }
+            // When inferredLLVM is ptr (from TYPEINFO_VAR generic param mapping)
+            // but the actual right-hand value is a concrete non-pointer type,
+            // use the actual value type. This handles `let temp = arr[j]` in a
+            // generic context where T=i32: arr[j] returns i32 but inferred_type
+            // is TYPEINFO_VAR → ptr.
+            if (inferredLLVM && inferredLLVM->isPointerTy() &&
+                rightVal.value && rightVal.value->getType() &&
+                !rightVal.value->getType()->isPointerTy()) {
+                inferredLLVM = nullptr;
+            }
             if (inferredLLVM && inferredLLVM != rightVal.value->getType()) {
                 // Convert the value to the inferred type (e.g., ptr -> i32 for ADT payloads)
                 if (inferredLLVM->isIntegerTy() && rightVal.value->getType()->isPointerTy()) {


### PR DESCRIPTION
修复泛型实例化中类型参数未传递到被调用函数的问题

    背景

    当一个泛型函数调用另一个泛型函数时（如 quicksort:[T] 内部调用 partition:[T]），编译器存在两个问题：

     1. mangled 名使用泛型参数名而非具体类型：partition:[T] 实例化后产生 partition__g_T，而不是 partition__g_i32
     2. 无显式类型参数时默认 i32：bindGenericTypeArgs(nullptr) 把所有泛型参数硬编码为 i32，而非从调用方继承
     3. `let temp = arr[j]` 被分配为 `ptr`：TYPEINFO_VAR 映射为 ptr，导致元素被 inttoptr 错误转换

    修改

     - Codegen.cpp/h — 新增 llvmTypeToToken() 将 LLVM Type\* 映射为 mangling token；bindGenericTypeArgs(nullptr) 改从
       activeGenericTypeBindings 继承绑定；instantiateGenericFunction 改为先绑定具体类型再 mangling
     - Funcs.cpp — visitCall 使用 instFn->getName().str() 替代 mangleGenericFunctionName() 获取正确 mangled 名
     - Stmts.cpp — visitAssign 中当 inferredLLVM 为 ptr（来自 TYPEINFO_VAR）但右值是非指针类型时，使用右值实际类型

    验证

    vlib-algorithm 的泛型 quicksort:[T] 对 [11, 23, 1, 3] 排序结果正确：1 3 11 23