### PR TITLE
feat(error): improve error reporting for moved values

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -59,6 +59,7 @@ void report_warning_with_location_and_snippet(const char* msg, const char* filen
 void report_unused_variable_warning(const char* variable_name, const char* filename, int line);
 void report_unused_variable_warning_with_location(const char* variable_name, const char* filename, int line, int column);
 void report_struct_field_missing_with_location_and_suggestion(const char* struct_name, const char* field_name, const char* suggestion, const char* filename, int line, int column);
+void adjust_column_to_identifier(const char* name);
 #ifdef __cplusplus
 }
 #endif

--- a/src/Ownership/Ownership.cpp
+++ b/src/Ownership/Ownership.cpp
@@ -42,6 +42,7 @@ struct VarState {
   const TypeInfo *type = nullptr; ///< Type information
   bool is_mutable = false;        ///< Whether mutable
   bool moved = false;             ///< Whether moved (ownership transferred)
+  ASTNode *moved_at = nullptr;    ///< AST node where the move occurred (for error reporting)
   bool is_global = false;         ///< Whether a global variable
   bool borrowed_shared =
       false;                 ///< Whether there is a shared (immutable) borrow
@@ -194,7 +195,16 @@ private:
    */
   void report(ASTNode *node, const std::string &message) {
     set_location_with_column(node_file(node), node_line(node), node_col(node));
-    report_simple_error(ERROR_LEVEL_ERROR, ERROR_SEMANTIC, message.c_str());
+    int length = 1;
+    // Extract variable name from messages like "use of moved value 'buf'"
+    auto start = message.find('\'');
+    auto end = message.find('\'', start + 1);
+    if (start != std::string::npos && end != std::string::npos && end > start) {
+      std::string vname = message.substr(start + 1, end - start - 1);
+      adjust_column_to_identifier(vname.c_str());
+      length = (int)vname.size();
+    }
+    report_simple_error_with_length(ERROR_LEVEL_ERROR, ERROR_SEMANTIC, message.c_str(), length);
     errors++;
   }
 
@@ -832,7 +842,15 @@ ExprInfo OwnershipChecker::check_identifier(ASTNode *node, ExprUse use) {
 
   // Check if using a moved value (unless as assignment target)
   if (use != ExprUse::AssignTarget && state->moved) {
-    report(node, std::string("use of moved value '") + cname + "'");
+    std::string msg = std::string("use of moved value '") + cname + "'";
+    if (state->moved_at) {
+      msg += "\n  note: '" + std::string(cname) + "' was moved here by passing to " +
+             std::string(node_file(state->moved_at)) + ":" +
+             std::to_string(node_line(state->moved_at));
+    }
+    adjust_column_to_identifier(cname);
+    adjust_column_to_identifier(cname);
+    report(node, msg);
     return info;
   }
   // Move semantics: if non-Copy type used with Move, mark as moved
@@ -843,6 +861,7 @@ ExprInfo OwnershipChecker::check_identifier(ASTNode *node, ExprUse use) {
              std::string("cannot move '") + cname + "' while it is borrowed");
     } else {
       state->moved = true;
+      state->moved_at = node;
       state->borrow_sources
           .clear(); // After move borrow relationships disappear
     }

--- a/src/parser/lexer.l
+++ b/src/parser/lexer.l
@@ -194,7 +194,7 @@ static int decode_char_literal(const char* text, size_t len, unsigned char* out)
         } \
     } while(0)
 
-#define GET_FIRST_COLUMN() (yycolumn - yyleng + 1)
+#define GET_FIRST_COLUMN() (yycolumn - yyleng)
 
 #define SET_TOKEN_LOCATION() \
     do { \
@@ -327,7 +327,8 @@ static int decode_char_literal(const char* text, size_t len, unsigned char* out)
 "?"                 { UPDATE_COLUMN(); SET_TOKEN_LOCATION(); RETURN_TOKEN(QUESTION); }
 
 [a-zA-Z_][a-zA-Z0-9_]*!?  {
-                        int col = GET_FIRST_COLUMN();
+     UPDATE_COLUMN();
+     int col = GET_FIRST_COLUMN();
                         yylval.str = strdup(yytext);
                         yylloc.first_line = yylineno;
                         yylloc.first_column = col;

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -320,6 +320,30 @@ static const char* error_type_to_string(ErrorType error_type) {
     }
 }
 
+static const char* error_type_code(ErrorType error_type) {
+    switch (error_type) {
+        case ERROR_SYNTAX:
+            return "E001";
+        case ERROR_LEXICAL:
+            return "E002";
+        case ERROR_TYPE:
+            return "E003";
+        case ERROR_UNDEFINED:
+        case ERROR_UNDEFINED_FUNC:
+            return "E004";
+        case ERROR_REDEFINITION:
+            return "E005";
+        case ERROR_SEMANTIC:
+            return "E006";
+        case ERROR_RUNTIME:
+            return "E007";
+        case ERROR_ARRAY_OUT_OF_BOUNDS:
+            return "E008";
+        default:
+            return "E099";
+    }
+}
+
 static const char* error_type_color(ErrorType error_type) {
     switch (error_type) {
         case ERROR_SYNTAX:
@@ -468,13 +492,15 @@ static void print_diagnostic_header(ErrorLevel level, ErrorType error_type, cons
     const char* level_text = level_label(level);
     const char* level_col = level_color(level);
     const char* type_text = error_type_to_string(error_type);
+    const char* err_code = error_type_code(error_type);
 
     fprintf(stderr, "%s%s%s%s", colorize(level_col), colorize(ANSI_BOLD), level_text, reset);
     if (type_text && error_type != ERROR_WARNING) {
-        fprintf(stderr, " %s[%s%s%s]%s",
+        fprintf(stderr, " %s[%s%s %s%s]%s",
                 colorize(ANSI_DIM),
                 colorize(error_type_color(error_type)),
                 type_text,
+                err_code ? err_code : "",
                 colorize(ANSI_DIM),
                 reset);
     }
@@ -541,6 +567,31 @@ void report_simple_error_with_length(ErrorLevel level, ErrorType error_type, con
 
 void report_simple_error(ErrorLevel level, ErrorType error_type, const char* msg) {
     report_simple_error_with_length(level, error_type, msg, 1);
+}
+
+void adjust_column_to_identifier(const char* name) {
+    if (!name || current_line <= 0) return;
+    char* line = get_line_content(current_line);
+    if (!line && current_filename && current_filename[0]) {
+        // Fallback: read file directly if source_content is not loaded
+        FILE* f = fopen(current_filename, "r");
+        if (f) {
+            char buf[4096];
+            for (int i = 1; i <= current_line && fgets(buf, sizeof(buf), f); i++) {
+                if (i == current_line) {
+                    line = strdup(buf);
+                    break;
+                }
+            }
+            fclose(f);
+        }
+    }
+    if (!line) return;
+    char* found = strstr(line, name);
+    if (found) {
+        current_column = (int)(found - line) + 1;
+    }
+    free(line);
 }
 
 void report_warning(const char* format, ...) {


### PR DESCRIPTION
- Add adjust_column_to_identifier() to pinpoint identifier column in errors
- Store moved_at node in VarState to show where the move occurred
- Include error code (e.g., E006) in diagnostic header
- Fix lexer column calculation for identifiers (GET_FIRST_COLUMN)
- Make ownership error messages include note with move location