### PR TITLE
fix(ownership): allow indirect mutable borrow writes, reset parser state

### DIFF
--- a/examples/mut_borrow_write_test.vix
+++ b/examples/mut_borrow_write_test.vix
@@ -1,0 +1,32 @@
+// Mutable borrow through pointer: write tests
+// Verifies: writing through a mutable borrow is the EXERCISE of the exclusive access
+//
+// NOTE on Vix syntax:
+//   @ptr.x is parsed as @(ptr.x) — dereference of ptr's field x.
+//   Since ptr is a pointer, ptr.x is invalid. Only simple @ptr is used here.
+
+type Point = struct { x: i32, y: i32 }
+
+// Test 1: Write through a mutable borrow (simple deref)
+fn test_mut_borrow_write(): i32
+{
+    let mut x = 10
+    let mut ptr = mut ref x   // Mutable borrow + mutable pointer binding
+    @ptr = 20                  // Write through the mutable borrow
+    return @ptr                 // Read back: should be 20
+}
+
+// Test 2: Read through a shared borrow is OK
+fn test_shared_borrow_read(): i32
+{
+    let x = 42
+    let ptr = ref x            // Shared borrow
+    return @ptr                 // Read through shared borrow: OK
+}
+
+fn main(): i32
+{
+    print(test_mut_borrow_write())
+    print(test_shared_borrow_read())
+    return 0
+}

--- a/examples/ownership_errors.vix
+++ b/examples/ownership_errors.vix
@@ -1,0 +1,197 @@
+// Comprehensive Ownership Test Suite — ERROR cases (should be rejected)
+// Covers: field-level borrow violations, NLL misuse, move/borrow conflicts
+
+type Point = struct { x: i32, y: i32 }
+
+// Top-level function for ownership transfer test
+fn take(xs: [i32]): i32 { xs[0] }
+
+// ────────────────────────────────────────────
+//  USE AFTER MOVE
+// ────────────────────────────────────────────
+
+fn err_use_after_move_simple(): i32
+{
+    let s = [1, 2, 3]
+    let t = s
+    print(s[0])          // error: use of moved value 's'
+    return 0
+}
+
+fn err_use_after_move_call(): i32
+{
+    let arr = [1, 2, 3]
+    take(arr)
+    print(arr[0])        // error: use of moved value 'arr'
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  MUTABLE BORROW CONFLICTS
+// ────────────────────────────────────────────
+
+fn err_mut_borrow_twice(): i32
+{
+    let mut v = 10
+    let r1 = mut ref v
+    let r2 = mut ref v   // error: cannot mutably borrow more than once
+    print(@r1)
+    return 0
+}
+
+fn err_imm_borrow_while_mut(): i32
+{
+    let mut y = 99
+    let ry = mut ref y
+    let ry2 = ref y      // error: cannot immutably borrow while mutably borrowed
+    print(@ry)
+    return 0
+}
+
+fn err_assign_while_mut_borrowed(): i32
+{
+    let mut x = 10
+    let r = mut ref x
+    x = 20               // error: cannot assign while mutably borrowed
+    print(@r)
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  MOVE WHILE BORROWED
+// ────────────────────────────────────────────
+
+fn err_move_while_shared_borrowed(): i32
+{
+    let s = [1, 2, 3]
+    let r = ref s[0]
+    let t = s            // error: cannot move while borrowed
+    print(@r)
+    return 0
+}
+
+fn err_move_while_mut_borrowed(): i32
+{
+    let mut s = [1, 2, 3]
+    let r = mut ref s
+    let t = s            // error: cannot move while mutably borrowed
+    print(@r)
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  DANGLING REFERENCE
+// ────────────────────────────────────────────
+
+fn err_return_local_ref(): ref i32
+{
+    let z = 1
+    return ref z         // error: cannot return reference to local variable
+}
+
+// ────────────────────────────────────────────
+//  BORROW MOVED VALUE
+// ────────────────────────────────────────────
+
+fn err_borrow_moved_value(): i32
+{
+    let s = [1, 2, 3]
+    let t = s
+    let r = ref s        // error: cannot borrow moved value 's'
+    print(@r)
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  FIELD-LEVEL BORROW VIOLATIONS
+// ────────────────────────────────────────────
+
+fn err_use_mut_borrowed_field(): i32
+{
+    let mut p = Point { x: 10, y: 20 }
+    let r = mut ref p.x
+    print(p.x)           // error: p.x is mutably borrowed, cannot use
+    @r
+    return 0
+}
+
+fn err_assign_to_mut_borrowed_field(): i32
+{
+    let mut p = Point { x: 10, y: 20 }
+    let r = mut ref p.x
+    p.x = 30             // error: cannot assign to mutably borrowed field
+    @r
+    return 0
+}
+
+fn err_assign_to_shared_borrowed_field(): i32
+{
+    let mut p = Point { x: 10, y: 20 }
+    let r = ref p.x
+    p.x = 30             // error: cannot assign to shared-borrowed field
+    @r
+    return 0
+}
+
+fn err_move_while_field_borrowed(): i32
+{
+    let p = Point { x: 10, y: 20 }
+    let r = ref p.x
+    let q = p            // error: cannot move 'p' while its fields are borrowed
+    print(@r)
+    return 0
+}
+
+fn err_use_whole_struct_while_fields_borrowed(): i32
+{
+    let p = Point { x: 1, y: 2 }
+    let r = ref p.x
+    print(p)             // error: cannot use 'p' while its fields are borrowed
+    @r
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  NLL EDGE CASES
+// ────────────────────────────────────────────
+
+// Borrow still alive: using x while r is still used later
+fn err_use_while_borrow_still_alive(): i32
+{
+    let x = 42
+    let r = ref x
+    print(x)             // error: cannot use x while r (used below) is alive
+    print(@r)            // r is used here!
+    return 0
+}
+
+// Multiple overlapping field mutable borrows conflict
+fn err_overlapping_field_mut_borrows(): i32
+{
+    let mut p = Point { x: 1, y: 2 }
+    let rx = mut ref p.x
+    let rx2 = mut ref p.x // error: cannot mutably borrow field twice
+    print(@rx)
+    return 0
+}
+
+fn main(): i32
+{
+    err_use_after_move_simple()
+    err_use_after_move_call()
+    err_mut_borrow_twice()
+    err_imm_borrow_while_mut()
+    err_assign_while_mut_borrowed()
+    err_move_while_shared_borrowed()
+    err_move_while_mut_borrowed()
+    err_return_local_ref()
+    err_borrow_moved_value()
+    err_use_mut_borrowed_field()
+    err_assign_to_mut_borrowed_field()
+    err_assign_to_shared_borrowed_field()
+    err_move_while_field_borrowed()
+    err_use_whole_struct_while_fields_borrowed()
+    err_use_while_borrow_still_alive()
+    err_overlapping_field_mut_borrows()
+    return 0
+}

--- a/examples/ownership_good.vix
+++ b/examples/ownership_good.vix
@@ -1,0 +1,251 @@
+// Comprehensive Ownership Test Suite — GOOD cases (should pass)
+// Covers: field-level borrows, NLL, mutable pointer write, combined patterns
+
+type Point = struct { x: i32, y: i32 }
+type Pair = struct { a: i32, b: i32 }
+
+// ────────────────────────────────────────────
+//  FIELD-LEVEL BORROW PRECISION
+// ────────────────────────────────────────────
+
+// Borrow p.x, read p.y (immutable)
+fn field_shared_borrow_other_field_readable(): i32
+{
+    let p = Point { x: 10, y: 20 }
+    let r = ref p.x
+    print(p.y)       // OK: other field not locked
+    @r
+    return 0
+}
+
+// Borrow p.x mutably, write p.y (immutable)
+fn field_mut_borrow_other_field_writable(): i32
+{
+    let mut p = Point { x: 10, y: 20 }
+    let r = mut ref p.x
+    p.y = 30         // OK: p.y is not borrowed
+    print(@r)
+    return 0
+}
+
+// Borrow p.x shared, borrow p.y shared — independent fields
+fn field_two_shared_borrows_on_different_fields(): i32
+{
+    let p = Point { x: 10, y: 20 }
+    let rx = ref p.x
+    let ry = ref p.y    // OK: different field
+    print(@rx + @ry)
+    return 0
+}
+
+// Borrow p.x shared, borrow whole p shared — overlap but both shared
+fn field_shared_borrow_plus_whole_shared_borrow(): i32
+{
+    let p = Point { x: 10, y: 20 }
+    let rf = ref p.x
+    let rp = ref p       // OK: whole-struct shared borrow coexists
+    print(@rf + @rp.y)
+    return 0
+}
+
+// Borrow p.x mutably, read p.y (field-level precision with mutable)
+fn field_mut_borrow_one_field_other_readable(): i32
+{
+    let mut p = Point { x: 10, y: 20 }
+    let mut r = mut ref p.x
+    print(p.y)       // OK: p.y not borrowed
+    @r = 99
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  NLL (NON-LEXICAL LIFETIMES)
+// ────────────────────────────────────────────
+
+// Shared borrow: use after borrower's last use
+fn nll_shared_borrow_read_after(): i32
+{
+    let x = 42
+    let r = ref x
+    print(@r)            // last use of r
+    print(x)             // OK: r dead, borrow released
+    return 0
+}
+
+// Mutable borrow: assign after borrower's last use
+fn nll_mut_borrow_assign_after(): i32
+{
+    let mut x = 10
+    let r = mut ref x
+    print(@r)            // last use of r
+    x = 30               // OK: r dead, mutable borrow released
+    print(x)
+    return 0
+}
+
+// Field borrow: use field after borrower's last use
+fn nll_field_borrow_use_after(): i32
+{
+    let mut p = Point { x: 1, y: 2 }
+    let r = ref p.x
+    print(@r)            // last use of r
+    p.x = 42             // OK: r dead, field borrow released
+    p.y = 99             // OK: r dead + field-level precision
+    print(p.x + p.y)
+    return 0
+}
+
+// NLL + if/else: borrow released after last use inside branch
+fn nll_after_if_else(): i32
+{
+    let mut x = 10
+    let r = ref x
+    print(@r)            // last use of r before if
+    if (1 < 2) {
+        x = 20           // OK: r dead
+    } else {
+        x = 30
+    }
+    print(x)
+    return 0
+}
+
+// NLL: multiple borrowers, one dies early
+fn nll_two_borrowers_one_dies_early(): i32
+{
+    let mut x = 10
+    let r1 = ref x
+    print(@r1)           // last use of r1 → r1 dead
+    x = 20               // OK: r1 dead, x writable again
+    let r2 = ref x       // fresh borrow
+    print(@r2)
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  MUTABLE BORROW + POINTER WRITE
+// ────────────────────────────────────────────
+
+// Write through mutable borrow
+fn mut_ptr_write_simple(): i32
+{
+    let mut x = 10
+    let mut ptr = mut ref x
+    @ptr = 20             // OK: writing through mutable borrow
+    return @ptr
+}
+
+// Write through mutable borrow, then re-borrow
+fn mut_ptr_write_then_reread(): i32
+{
+    let mut x = 10
+    let mut ptr = mut ref x
+    @ptr = 99
+    print(@ptr)
+    // ptr's last use — borrow released
+    x = 100               // OK: direct write after ptr dead
+    return x
+}
+
+// ────────────────────────────────────────────
+//  MOVE / COPY SEMANTICS
+// ────────────────────────────────────────────
+
+// Copy type: i32 not moved
+fn copy_type_not_moved(): i32
+{
+    let x = 10
+    let y = x             // x is i32, copy type
+    print(x + y)          // OK: both usable
+    return 0
+}
+
+// Move then reinitialize
+fn move_then_reinit(): i32
+{
+    let mut s = [1, 2, 3]
+    let t = s             // s moved
+    print(t[0])
+    s = [4, 5]        // OK: re-initialization (reassign)
+    print(s[0])
+    return 0
+}
+
+// ────────────────────────────────────────────
+//  COMBINED PATTERNS
+// ────────────────────────────────────────────
+
+// Field borrow + NLL + pointer write combined
+fn combined_field_nll_ptr(): i32
+{
+    let mut p = Point { x: 1, y: 2 }
+    let r = ref p.x
+    print(@r)              // last use of r
+    p.y = 99               // OK: NLL + field-level
+    return 0
+}
+
+// While loop with inner borrow (borrow released each iteration)
+fn while_loop_inner_borrow(): i32
+{
+    let mut sum = 0
+    let mut i = 0
+    while (i < 3) {
+        let r = ref sum    // borrow inside loop scope
+        print(@r)
+        i = i + 1
+    }
+    print(sum)             // OK: borrow released
+    return 0
+}
+
+// If/else with field borrow merge
+fn if_else_field_borrow_merge(): i32
+{
+    let mut p = Point { x: 1, y: 2 }
+    let cond = 1 < 2
+    if (cond) {
+        let r = ref p.x
+        print(@r)
+    } else {
+        let r = ref p.y
+        print(@r)
+    }
+    p.x = 10               // OK: borrows released in both branches
+    p.y = 20
+    print(p.x + p.y)
+    return 0
+}
+
+// Struct literal with borrow sources propagation
+fn struct_literal_with_borrow(): i32
+{
+    let y = 10
+    let p = Point { x: 5, y: y }
+    let r = ref p.x
+    print(@r + p.y)
+    return 0
+}
+
+fn main(): i32
+{
+    field_shared_borrow_other_field_readable()
+    field_mut_borrow_other_field_writable()
+    field_two_shared_borrows_on_different_fields()
+    field_shared_borrow_plus_whole_shared_borrow()
+    field_mut_borrow_one_field_other_readable()
+    nll_shared_borrow_read_after()
+    nll_mut_borrow_assign_after()
+    nll_field_borrow_use_after()
+    nll_after_if_else()
+    nll_two_borrowers_one_dies_early()
+    mut_ptr_write_simple()
+    mut_ptr_write_then_reread()
+    copy_type_not_moved()
+    move_then_reinit()
+    combined_field_nll_ptr()
+    while_loop_inner_borrow()
+    if_else_field_borrow_merge()
+    struct_literal_with_borrow()
+    return 0
+}

--- a/include/parser.h
+++ b/include/parser.h
@@ -16,6 +16,7 @@ ASTNode* vix_adt_ctor_payload_type_node(const char* ctor_name);
 ASTNode* vix_adt_payload_type_for_base(const char* base_name);
 int vix_adt_ctor_index(const char* ctor_name);
 const char* vix_lookup_impl_method(const char* type_name, const char* method_name);
+void vix_reset_parser_state(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/Ownership/Ownership.cpp
+++ b/src/Ownership/Ownership.cpp
@@ -1027,39 +1027,55 @@ void OwnershipChecker::check_assign(ASTNode *node) {
     if (target_state) {
       log_var_modification(target_state);
 
+      // --- Determine field-level vs whole-variable write ---
+      // Strip leading deref nodes to check if the lvalue is a member access
+      // (this is hoisted before the is_indirect fork so BOTH paths can use it)
+      ASTNode *lv = left;
+      while (lv && lv->type == AST_UNARYOP &&
+             lv->data.unaryop.op == OP_DEREF) {
+        lv = lv->data.unaryop.expr;
+      }
+      bool is_field_assign = (lv && lv->type == AST_MEMBER_ACCESS);
+      std::string assign_field = field_name(lv);
+
       // --- Distinguish direct assignment from indirect (dereference)
       // --- assignment ---
       bool is_indirect = (deref_count > 0);
 
       if (is_indirect) {
-        // Indirect assignment: *ptr = expr, etc.
-        // The pointer itself is only read; its ownership must NOT change, but
-        // we must ensure it is still alive and not borrowed.
+        // Indirect assignment: *ptr = expr, or @ptr.field = expr.
+        // The pointer itself is only read; its ownership must NOT change.
+        //
+        // CRITICAL: whole_borrowed_mut is set BY the mutable borrow we are
+        // now exercising — it is the grant of exclusive access, not a
+        // prohibition.  Only whole_borrowed_shared blocks indirect writes
+        // (writing through a shared borrow is illegal).
         if (target_state->moved) {
           report(left, "use of moved value '" + target + "'");
           return;
         }
-        if (target_state->whole_borrowed_shared ||
-            target_state->whole_borrowed_mut ||
-            has_active_field_borrows(*target_state)) {
+        if (target_state->whole_borrowed_shared) {
           report(left, "cannot assign through '" + target +
-                           "' while it is borrowed");
+                           "' while it is immutably borrowed");
           return;
+        }
+        // Field-level borrow check for writes through a pointer.
+        if (is_field_assign && !assign_field.empty()) {
+          auto fit = target_state->field_borrows.find(assign_field);
+          if (fit != target_state->field_borrows.end()) {
+            if (fit->second.borrowed_mut ||
+                fit->second.borrowed_shared) {
+              report(left, "cannot assign to '" + target + "." +
+                               assign_field +
+                               "' through pointer while it is borrowed");
+              return;
+            }
+          }
         }
         // No state mutation for the pointer.
       } else {
         // Direct assignment to a variable or its field (e.g. x = ...,
         // x.field = ...)
-
-        // Determine if this is a field assignment
-        ASTNode *lv = left;
-        while (lv && lv->type == AST_UNARYOP &&
-               lv->data.unaryop.op == OP_DEREF) {
-          lv = lv->data.unaryop.expr;
-        }
-        bool is_field_assign =
-            (lv && lv->type == AST_MEMBER_ACCESS);
-        std::string assign_field = field_name(lv);
 
         // --- Borrow conflict check ---
         if (is_field_assign && !assign_field.empty()) {
@@ -1564,8 +1580,16 @@ void OwnershipChecker::check_node(ASTNode *node) {
     return;
   switch (node->type) {
   case AST_PROGRAM:
+    // NLL pre-scan for top-level statements (globals, top-level expressions)
+    last_use_seq.clear();
+    current_seq = 0;
+    {
+      int seq = 0;
+      scan_last_use_seq(node, seq, last_use_seq);
+    }
     check_block(node, false);
     cleanup_borrows();
+    last_use_seq.clear();
     break;
   case AST_FUNCTION:
     check_function(node);

--- a/src/compiler/Attrs.cpp
+++ b/src/compiler/Attrs.cpp
@@ -97,3 +97,20 @@ SourceAttrInfo parseSourceAttributes(const char* filePath) {
 
     return info;
 }
+
+extern "C" int vix_source_has_attr_no_std(const char *filePath) {
+    SourceAttrInfo info = parseSourceAttributes(filePath);
+    return info.noStd ? 1 : 0;
+}
+
+extern "C" int vix_source_has_attr_no_main(const char *filePath) {
+    SourceAttrInfo info = parseSourceAttributes(filePath);
+    return info.noMain ? 1 : 0;
+}
+
+extern "C" int vix_source_get_attrs(const char *filePath, int *out_no_std, int *out_no_main) {
+    SourceAttrInfo info = parseSourceAttributes(filePath);
+    if (out_no_std)  *out_no_std  = info.noStd  ? 1 : 0;
+    if (out_no_main) *out_no_main = info.noMain ? 1 : 0;
+    return 0;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -53,603 +53,452 @@ static int vix_clock_gettime(int unused, struct timespec *ts) {
 
 extern FILE *yyin;
 extern ASTNode *root;
+const char *current_input_filename = NULL;
+
+#define MAX_OBJ_FILES 256
+#define MAX_LIB_PATHS 64
+#define MAX_EXTRA_LIBS 64
+
+/** All parsed CLI options, stored as a struct for clean passing between phases */
+typedef struct {
+  char *in_f;
+  char *out_f;
+  char *llvm_f;
+  char *obj_f;
+  char *asm_f;
+  char *target;
+  int is_vic;
+  int save_c;
+  int gen_llvm;
+  int gen_obj;
+  int gen_asm;
+  int out_ast;
+  int out_llvm;
+  int dbg;
+  int opt_level;
+  int no_std;
+  int no_main;
+  int check_only;
+  int show_time;
+  int link_mode;
+  int static_link;
+  char *obj_files[MAX_OBJ_FILES];
+  int obj_file_count;
+  char *lib_paths[MAX_LIB_PATHS];
+  int lib_path_count;
+  char *extra_libs[MAX_EXTRA_LIBS];
+  int extra_lib_count;
+} VixOptions;
+
+/* ── Forward declarations ──────────────────── */
+static void print_usage(const char *prog);
+static int parse_args(VixOptions *opts, int argc, char **argv);
+static int run_linker_mode(const VixOptions *opts);
+static int run_compiler_pipeline(const VixOptions *opts, FILE *input_file);
 static void print_timing_table(struct timespec t_start, struct timespec t_file,
                                struct timespec t_parse, struct timespec t_sema,
                                struct timespec t_codegen);
-const char *current_input_filename = NULL;
-static const char *find_bundled_libc(void) {
-  static char libc_path[4096];
-  char exe_dir[4096];
+static const char *find_bundled_libc(void);
 
-#ifdef _WIN32
-  DWORD len = GetModuleFileNameA(NULL, exe_dir, sizeof(exe_dir));
-  if (len == 0 || len >= sizeof(exe_dir))
-    return NULL;
-  char *last_sep = strrchr(exe_dir, '\\');
-  if (!last_sep)
-    last_sep = strrchr(exe_dir, '/');
-  if (last_sep)
-    *last_sep = '\0';
-#else
-  ssize_t len = readlink("/proc/self/exe", exe_dir, sizeof(exe_dir) - 1);
-  if (len <= 0)
-    return NULL;
-  exe_dir[len] = '\0';
-  char *last_sep = strrchr(exe_dir, '/');
-  if (last_sep)
-    *last_sep = '\0';
-#endif
-  static const char *const suffixes[] = {
-#ifdef _WIN32
-      "\\..\\libc", "\\libc",
-#else
-      "/../libc", "/libc",
-#endif
-      NULL};
+/* extern C wrappers from compiler/Attrs.cpp */
+extern int vix_source_get_attrs(const char *filePath, int *out_no_std, int *out_no_main);
+/* parser global state reset (parser.y) */
+extern void vix_reset_parser_state(void);
 
-  for (const char *const *s = suffixes; *s; ++s) {
-    snprintf(libc_path, sizeof(libc_path), "%s%s", exe_dir, *s);
-#ifdef _WIN32
-    DWORD attr = GetFileAttributesA(libc_path);
-    if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY))
-      return libc_path;
-#else
-    /* Check if directory exists by trying to stat it */
-    struct stat st;
-    if (stat(libc_path, &st) == 0 && S_ISDIR(st.st_mode))
-      return libc_path;
-#endif
-  }
-
-  return NULL;
-}
-
+/* ==================================================================
+ * main — entry point
+ * ================================================================== */
 int main(int argc, char **argv) {
+  VixOptions opts;
+  memset(&opts, 0, sizeof(opts));
+
   if (argc < 2) {
-    fprintf(stderr, "OVERVIEW: Vix Compiler\n\n");
-    fprintf(stderr, "USAGE: %s [options] <input.vix>\n", argv[0]);
-    fprintf(stderr, "       %s file1.o file2.o ... -o <output>\n\n", argv[0]);
-    fprintf(stderr, "OPTIONS:\n");
-    fprintf(stderr, "  -o <file>              Write output to <file>\n");
-    fprintf(stderr, "  -S [file]              Emit assembly to <file> "
-                    "(default: <input>.s)\n");
-    fprintf(stderr, "  -obj [file]            Emit object file to <file> "
-                    "(default: <input>.o)\n");
-    fprintf(stderr, "  -ll [file]             Emit LLVM IR to <file> (default: "
-                    "<input>.ll)\n");
-    fprintf(stderr, "  -llvm                  Print LLVM IR to stdout\n");
-    fprintf(stderr, "  -ast                   Print AST to stdout\n");
-    fprintf(stderr,
-            "  -opt=lN                Set optimization level (N = 0..3)\n");
-    fprintf(stderr,
-            "  --target=<triple>      Set codegen/link target triple\n");
-    fprintf(stderr,
-            "  -static                Static linking (default: dynamic)\n");
-    fprintf(stderr, "  -L <path>              Add library search path\n");
-    fprintf(stderr, "  --check                Syntax & type check only\n");
-    fprintf(stderr, "  --time                 Show phase timing breakdown\n");
-    fprintf(stderr, "  --debug                Enable debug output\n");
-    fprintf(stderr,
-            "  -v, --version          Display compiler version information\n");
-    fprintf(stderr, "  -h, --help             Display this help message\n");
+    print_usage(argv[0]);
     return 1;
   }
 
-  char *out_f = NULL;
-  char *llvm_f = NULL;
-  char *obj_f = NULL;
-  char *asm_f = NULL;
-  char *in_f = NULL;
-  int is_vic = 0;
-  int save_c = 0;
-  int gen_llvm = 0;
-  int gen_obj = 0;
-  int gen_asm = 0;
-  int out_ast = 0;
-  int out_llvm = 0;
-  int dbg = 0;
-  int opt_level = 0;
-  char *target = NULL;
-  int no_std = 0;
-  int no_main = 0;
-  int check_only = 0;
-  int show_time = 0;
-#define MAX_OBJ_FILES 256
-  char *obj_files[MAX_OBJ_FILES];
-  int obj_file_count = 0;
-  int link_mode = 0;
-  int static_link = 0;
-#define MAX_LIB_PATHS 64
-  char *lib_paths[MAX_LIB_PATHS];
-  int lib_path_count = 0;
-#define MAX_EXTRA_LIBS 64
-  char *extra_libs[MAX_EXTRA_LIBS];
-  int extra_lib_count = 0;
+  if (!parse_args(&opts, argc, argv))
+    return 1; /* parse_args already printed the error */
+
+  vix_setenv("VIX_DEBUG", opts.dbg ? "1" : "0", 1);
+  vix_set_opt_level(opts.opt_level);
+
+  /* ── Linker mode: link .o files into executable ── */
+  if (opts.link_mode && opts.obj_file_count > 0)
+    return run_linker_mode(&opts);
+
+  /* ── Compiler mode: source → LLVM IR / object / executable ── */
+  if (!opts.in_f) {
+    fprintf(stderr, "Error: no input file specified\n");
+    return 1;
+  }
+
+  FILE *input_file = fopen(opts.in_f, "r");
+  if (!input_file) {
+    perror("Failed to open file");
+    return 1;
+  }
+
+  /* Scan for #[no_std] / #[no_main] attributes via source parser (one file read) */
+  vix_source_get_attrs(opts.in_f, &opts.no_std, &opts.no_main);
+
+  /* Reset parser global state across compilations, then compile */
+  vix_reset_parser_state();
+  int ret = run_compiler_pipeline(&opts, input_file);
+
+  fclose(input_file);
+  return ret;
+}
+
+/* ==================================================================
+ * Usage / Help
+ * ================================================================== */
+static void print_usage(const char *prog) {
+  fprintf(stderr, "OVERVIEW: Vix Compiler\n\n");
+  fprintf(stderr, "USAGE: %s [options] <input.vix>\n", prog);
+  fprintf(stderr, "       %s file1.o file2.o ... -o <output>\n\n", prog);
+  fprintf(stderr, "OPTIONS:\n");
+  fprintf(stderr, "  -o <file>              Write output to <file>\n");
+  fprintf(stderr, "  -S [file]              Emit assembly to <file> "
+                  "(default: <input>.s)\n");
+  fprintf(stderr, "  -obj [file]            Emit object file to <file> "
+                  "(default: <input>.o)\n");
+  fprintf(stderr, "  -ll [file]             Emit LLVM IR to <file> (default: "
+                  "<input>.ll)\n");
+  fprintf(stderr, "  -llvm                  Print LLVM IR to stdout\n");
+  fprintf(stderr, "  -ast                   Print AST to stdout\n");
+  fprintf(stderr,
+          "  -opt=lN                Set optimization level (N = 0..3)\n");
+  fprintf(stderr,
+          "  --target=<triple>      Set codegen/link target triple\n");
+  fprintf(stderr,
+          "  -static                Static linking (default: dynamic)\n");
+  fprintf(stderr, "  -L <path>              Add library search path\n");
+  fprintf(stderr, "  -l <lib>               Link with library\n");
+  fprintf(stderr, "  --check                Syntax & type check only\n");
+  fprintf(stderr, "  --time                 Show phase timing breakdown\n");
+  fprintf(stderr, "  --debug                Enable debug output\n");
+  fprintf(stderr,
+          "  -v, --version          Display compiler version information\n");
+  fprintf(stderr, "  -h, --help             Display this help message\n");
+}
+
+/* ==================================================================
+ * CLI argument parsing
+ * ================================================================== */
+static int parse_args(VixOptions *opts, int argc, char **argv) {
   for (int i = 1; i < argc; i++) {
     if (strncmp(argv[i], "--target=", 9) == 0) {
-      target = argv[i] + 9;
+      opts->target = argv[i] + 9;
     } else if (strcmp(argv[i], "--target") == 0) {
-      if (i + 1 < argc) {
-        target = argv[i + 1];
-        i++;
-      } else {
-        fprintf(stderr, "Er: --target option requires a target triple\n");
-        return 1;
-      }
+      if (i + 1 < argc) { opts->target = argv[++i]; }
+      else { fprintf(stderr, "Error: --target requires a triple\n"); return 0; }
     } else if (strcmp(argv[i], "-o") == 0) {
-      if (i + 1 < argc) {
-        out_f = argv[i + 1];
-        save_c = 1;
-        i++;
-      } else {
-        fprintf(stderr, "Er: -o option requires a filename\n");
-        return 1;
-      }
-    } else if (strcmp(argv[i], "-v") == 0 ||
-               strcmp(argv[i], "--version") == 0 ||
+      if (i + 1 < argc) { opts->out_f = argv[++i]; opts->save_c = 1; }
+      else { fprintf(stderr, "Error: -o requires a filename\n"); return 0; }
+    } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0 ||
                strcmp(argv[i], "-ver") == 0) {
       printf("Vix Compiler 0.4.2 Copyright(c) 2025-2026 LLVM : 22.1.2(8)\n");
-      return 0;
+      exit(0);
     } else if (strcmp(argv[i], "-llvm") == 0) {
-      out_llvm = 1;
+      opts->out_llvm = 1;
     } else if (strcmp(argv[i], "-obj") == 0) {
-      gen_obj = 1;
-      gen_llvm = 1;
-      if (i + 1 < argc && argv[i + 1][0] != '-') {
-        obj_f = argv[i + 1];
-        i++;
-      }
+      opts->gen_obj = 1; opts->gen_llvm = 1;
+      if (i + 1 < argc && argv[i + 1][0] != '-') opts->obj_f = argv[++i];
     } else if (strcmp(argv[i], "-S") == 0 || strcmp(argv[i], "-s") == 0) {
-      gen_asm = 1;
-      gen_llvm = 1;
-      if (i + 1 < argc && argv[i + 1][0] != '-') {
-        asm_f = argv[i + 1];
-        i++;
-      }
+      opts->gen_asm = 1; opts->gen_llvm = 1;
+      if (i + 1 < argc && argv[i + 1][0] != '-') opts->asm_f = argv[++i];
     } else if (strcmp(argv[i], "-ll") == 0) {
-      if (i + 1 < argc && argv[i + 1][0] != '-') {
-        llvm_f = argv[i + 1];
-        gen_llvm = 1;
-        i++;
-      } else {
-        out_llvm = 1;
-      }
+      if (i + 1 < argc && argv[i + 1][0] != '-') { opts->llvm_f = argv[++i]; opts->gen_llvm = 1; }
+      else { opts->out_llvm = 1; }
     } else if (strcmp(argv[i], "-ast") == 0 || strcmp(argv[i], "--ast") == 0) {
-      out_ast = 1;
+      opts->out_ast = 1;
     } else if (strcmp(argv[i], "--debug") == 0) {
-      dbg = 1;
+      opts->dbg = 1;
     } else if (strcmp(argv[i], "--check") == 0) {
-      check_only = 1;
+      opts->check_only = 1;
     } else if (strcmp(argv[i], "--time") == 0) {
-      show_time = 1;
+      opts->show_time = 1;
     } else if (strncmp(argv[i], "-opt=l", 6) == 0) {
       int lvl = argv[i][6] - '0';
       if (lvl < 0 || lvl > 3 || argv[i][7] != '\0') {
-        fprintf(stderr, "Error: -opt=lN requires N in 0..3 (got %s)\n",
-                argv[i]);
-        return 1;
+        fprintf(stderr, "Error: -opt=lN requires N in 0..3 (got %s)\n", argv[i]);
+        return 0;
       }
-      opt_level = lvl;
+      opts->opt_level = lvl;
     } else if (strcmp(argv[i], "-static") == 0) {
-      static_link = 1;
+      opts->static_link = 1;
     } else if (strcmp(argv[i], "-L") == 0) {
-      if (i + 1 < argc) {
-        if (lib_path_count < MAX_LIB_PATHS) {
-          lib_paths[lib_path_count++] = argv[i + 1];
-        }
-        i++;
-      } else {
-        fprintf(stderr, "Error: -L option requires a path\n");
-        return 1;
-      }
+      if (i + 1 < argc && opts->lib_path_count < MAX_LIB_PATHS) opts->lib_paths[opts->lib_path_count++] = argv[++i];
+      else { fprintf(stderr, "Error: -L requires a path\n"); return 0; }
     } else if (strcmp(argv[i], "-l") == 0) {
-      if (i + 1 < argc) {
-        if (extra_lib_count < MAX_EXTRA_LIBS) {
-          extra_libs[extra_lib_count++] = argv[i + 1];
-        }
-        i++;
-      } else {
-        fprintf(stderr, "Error: -l option requires a library name\n");
-        return 1;
-      }
+      if (i + 1 < argc && opts->extra_lib_count < MAX_EXTRA_LIBS) opts->extra_libs[opts->extra_lib_count++] = argv[++i];
+      else { fprintf(stderr, "Error: -l requires a library name\n"); return 0; }
     } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
-      fprintf(stderr, "OVERVIEW: Vix Compiler LLVM Version:22.1.2(8)\n\n");
-      fprintf(stderr, "OPTIONS:\n");
-      fprintf(stderr, "USAGE: %s [options] <input.vix>\n", argv[0]);
-      fprintf(stderr, "       %s file1.o file2.o ... -o <output>\n\n", argv[0]);
-      fprintf(stderr, "  -o <file>              Write output to <file>\n");
-      fprintf(stderr, "  -S [file]              Emit assembly to <file> "
-                      "(default: <input>.s)\n");
-      fprintf(stderr, "  -obj [file]            Emit object file to <file> "
-                      "(default: <input>.o)\n");
-      fprintf(stderr, "  -ll [file]             Emit LLVM IR to <file> "
-                      "(default: <input>.ll)\n");
-      fprintf(stderr, "  -llvm                  Print LLVM IR to stdout\n");
-      fprintf(stderr, "  -ast                   Print AST to stdout\n");
-      fprintf(stderr,
-              "  -opt=lN                Set optimization level (N = 0..3)\n");
-      fprintf(stderr,
-              "  --target=<triple>      Set codegen/link target triple\n");
-      fprintf(stderr,
-              "  -static                Static linking (default: dynamic)\n");
-      fprintf(stderr, "  -L <path>              Add library search path\n");
-      fprintf(stderr, "  -l <lib>               Link with library\n");
-      fprintf(stderr, "  --check                Syntax & type check only\n");
-      fprintf(stderr, "  --time                 Show phase timing breakdown\n");
-      fprintf(stderr, "  --debug                Enable debug output\n");
-      fprintf(
-          stderr,
-          "  -v, --version          Display compiler version information\n");
-      fprintf(stderr, "  -h, --help             Display this help message\n");
-      return 0;
+      print_usage(argv[0]);
+      exit(0);
     } else if (argv[i][0] == '-' && strcmp(argv[i], "-") != 0) {
       fprintf(stderr, "Unknown option: %s\n", argv[i]);
-      return 1;
+      return 0;
     } else {
       size_t len = strlen(argv[i]);
       if (len > 2 && strcmp(argv[i] + len - 2, ".o") == 0) {
-        if (obj_file_count < MAX_OBJ_FILES) {
-          obj_files[obj_file_count++] = argv[i];
-          link_mode = 1;
+        if (opts->obj_file_count < MAX_OBJ_FILES) {
+          opts->obj_files[opts->obj_file_count++] = argv[i];
+          opts->link_mode = 1;
         } else {
-          fprintf(stderr, "Error: too many object files (max %d)\n",
-                  MAX_OBJ_FILES);
-          return 1;
+          fprintf(stderr, "Error: too many object files (max %d)\n", MAX_OBJ_FILES);
+          return 0;
         }
       } else {
-        in_f = argv[i];
-        is_vic = len > 4 && strcmp(argv[i] + len - 4, ".vic") == 0;
+        opts->in_f = argv[i];
+        opts->is_vic = len > 4 && strcmp(argv[i] + len - 4, ".vic") == 0;
       }
     }
   }
-  vix_setenv("VIX_DEBUG", dbg ? "1" : "0", 1); // 通过环境变量控制调试输出
-  vix_set_opt_level(opt_level);
+  return 1;
+}
 
-  if (link_mode && obj_file_count > 0) {
-    if (!out_f) {
-      fprintf(stderr,
-              "Error: -o <output> required when linking object files\n");
-      return 1;
-    }
-
-    const char *eff_t = target;
-    int bare = 0;
-    if (eff_t && (strstr(eff_t, "unknown-none") != NULL ||
-                  strstr(eff_t, "unknow-noe") != NULL)) {
-      bare = 1;
-    }
-
-    const char *ls = NULL;
-    if (bare) {
-      ls = "linker.ld";
-      if (!vix_file_readable(ls) && vix_file_readable("src/linker.ld")) {
-        ls = "src/linker.ld";
-      }
-    }
-
-    const char *link_err = NULL;
-    VixLinkOptions link_opts = {
-        .target_triple = eff_t,
-        .bare_mode = bare,
-        .linker_script = ls,
-        .static_link = bare || static_link,
-        .entry_point = bare ? "_start" : NULL,
-        .libc_dir = find_bundled_libc(),
-        .lib_paths = lib_path_count > 0 ? (const char **)lib_paths : NULL,
-        .lib_path_count = lib_path_count,
-        .extra_libs = extra_lib_count > 0 ? (const char **)extra_libs : NULL,
-        .extra_lib_count = extra_lib_count,
-    };
-
-    if (!vix_link_multi((const char **)obj_files, obj_file_count, out_f,
-                        &link_opts, &link_err)) {
-      fprintf(stderr, "Error: Failed to link object files");
-      if (link_err && link_err[0] != '\0') {
-        fprintf(stderr, ":\n%s", link_err);
-      }
-      fprintf(stderr, "\n");
-      return 1;
-    }
-    return 0;
-  }
-
-  if (!in_f) {
-    in_f = argv[1];
-  }
-  int exp_mode = out_ast || out_llvm || gen_llvm || gen_obj || gen_asm;
-
-  if (!exp_mode && !out_f && save_c == 0) {
-    char *dot = strrchr(in_f, '.');
-    if (dot) {
-      size_t len = dot - in_f;
-#ifdef _WIN32
-      char *def_out = malloc(len + 5);
-#else
-      char *def_out = malloc(len + 1);
-#endif
-      if (def_out) {
-        strncpy(def_out, in_f, len);
-        def_out[len] = '\0';
-#ifdef _WIN32
-        strcat(def_out, ".exe");
-#endif
-        out_f = def_out;
-        save_c = 1;
-      }
-    } else {
-#ifdef _WIN32
-      char *def_out = malloc(strlen(in_f) + 5);
-      if (def_out) {
-        strcpy(def_out, in_f);
-        strcat(def_out, ".exe");
-        out_f = def_out;
-        save_c = 1;
-      } else {
-        out_f = in_f;
-        save_c = 1;
-      }
-#else
-      out_f = in_f;
-      save_c = 1;
-#endif
-    }
-  }
-
-  FILE *input_file = fopen(in_f, "r");
-  if (!input_file) {
-    perror("Failed to open file");
-    if (out_f && out_f != in_f && out_f != argv[1]) {
-      free(out_f);
-    }
+/* ==================================================================
+ * Linker mode: .o files → executable
+ * ================================================================== */
+static int run_linker_mode(const VixOptions *opts) {
+  if (!opts->out_f) {
+    fprintf(stderr, "Error: -o <output> required when linking object files\n");
     return 1;
   }
+  const char *eff_t = opts->target;
+  int bare = eff_t && (strstr(eff_t, "unknown-none") != NULL);
 
-  {
-    char buf[1024];
-    while (fgets(buf, sizeof(buf), input_file) != NULL) {
-      if (strstr(buf, "#[no_std]") != NULL) {
-        no_std = 1;
-      }
-      if (strstr(buf, "#[no_main]") != NULL) {
-        no_main = 1;
-      }
-    }
-    rewind(input_file);
+  const char *ls = NULL;
+  if (bare) {
+    ls = "linker.ld";
+    if (!vix_file_readable(ls) && vix_file_readable("src/linker.ld"))
+      ls = "src/linker.ld";
   }
 
+  const char *link_err = NULL;
+  VixLinkOptions link_opts = {
+    .target_triple = eff_t,
+    .bare_mode = bare,
+    .linker_script = ls,
+    .static_link = bare || opts->static_link,
+    .entry_point = bare ? "_start" : NULL,
+    .libc_dir = find_bundled_libc(),
+    .lib_paths = opts->lib_path_count > 0 ? (const char **)opts->lib_paths : NULL,
+    .lib_path_count = opts->lib_path_count,
+    .extra_libs = opts->extra_lib_count > 0 ? (const char **)opts->extra_libs : NULL,
+    .extra_lib_count = opts->extra_lib_count,
+  };
+
+  if (!vix_link_multi((const char **)opts->obj_files, opts->obj_file_count,
+                      opts->out_f, &link_opts, &link_err)) {
+    fprintf(stderr, "Error: Failed to link object files");
+    if (link_err && link_err[0] != '\0') fprintf(stderr, ":\n%s", link_err);
+    fprintf(stderr, "\n");
+    return 1;
+  }
+  return 0;
+}
+
+/* ==================================================================
+ * Compiler pipeline: parse → semantic → typeck → ownership → codegen
+ * ================================================================== */
+static int run_compiler_pipeline(const VixOptions *opts, FILE *input_file) {
+  int result = 1; /* default: failure */
   struct timespec t_start, t_file_ts, t_parse_ts, t_sema_ts, t_codegen_ts;
-  if (show_time)
-    clock_gettime(CLOCK_MONOTONIC, &t_start);
 
-  const char *eff_t = target;
-  if (!eff_t && (no_std || no_main)) {
+  /* Derive effective target triple */
+  const char *eff_t = opts->target;
+  if (!eff_t && (opts->no_std || opts->no_main))
     eff_t = "x86_64-unknown-none";
-  }
+
 #ifndef VIXC_FRONTEND_ONLY
   llvm_set_target_triple(eff_t);
 #endif
 
-  int bare = 0;
-  if (eff_t && (strstr(eff_t, "unknown-none") != NULL ||
-                strstr(eff_t, "unknow-noe") != NULL)) {
-    bare = 1;
-  }
-  if (no_std || no_main) {
-    bare = 1;
-  }
+  int bare = eff_t && (strstr(eff_t, "unknown-none") != NULL);
+  if (opts->no_std || opts->no_main) bare = 1;
 
-  if (save_c) {
-    gen_llvm = 1;
-    if (!llvm_f) {
-      char *dot = strrchr(out_f, '.');
-      if (dot) {
-        size_t len = dot - out_f;
-        char *llvm_name = malloc(len + 4);
-        if (llvm_name) {
-          strncpy(llvm_name, out_f, len);
-          llvm_name[len] = '\0';
-          strcat(llvm_name, ".ll");
-          llvm_f = llvm_name;
-        }
-      } else {
-        char *llvm_name = malloc(strlen(out_f) + 4);
-        if (llvm_name) {
-          strcpy(llvm_name, out_f);
-          strcat(llvm_name, ".ll");
-          llvm_f = llvm_name;
-        }
-      }
+  /* Default output filename */
+  int free_out_f = 0;
+  if (!opts->gen_llvm && !opts->out_ast && !opts->out_llvm &&
+      !opts->out_f && !opts->save_c && opts->in_f) {
+    char *dot = strrchr(opts->in_f, '.');
+    size_t base_len = dot ? (size_t)(dot - opts->in_f) : strlen(opts->in_f);
+    char *def_out = malloc(base_len + 1);
+    if (def_out) {
+      strncpy(def_out, opts->in_f, base_len);
+      def_out[base_len] = '\0';
+#ifdef _WIN32
+      char *tmp = realloc(def_out, base_len + 5);
+      if (tmp) { def_out = tmp; strcat(def_out, ".exe"); }
+#endif
+      /* Cast away const — opts->out_f points to malloc'd memory we own */
+      *(char **)&opts->out_f = def_out;
+      *(int *)&opts->save_c = 1;
+      free_out_f = 1;
     }
   }
 
-  (void)is_vic;
-
-  current_input_filename = in_f;
-  load_source_file(in_f);
-  set_location_with_column(in_f, 1, 1);
-  yyin = input_file;
-
-  if (show_time)
-    clock_gettime(CLOCK_MONOTONIC, &t_file_ts);
-
-  int result = yyparse();
-  if (result == 0 && root) {
-    inline_imports(root);
+  /* LLVM IR output path */
+  char llvm_filename[2048];
+  const char *llvm_f = opts->llvm_f;
+  if (opts->save_c && !llvm_f) {
+    const char *base = opts->out_f ? opts->out_f : opts->in_f;
+    char *dot = strrchr(base, '.');
+    if (dot) {
+      size_t len = dot - base;
+      snprintf(llvm_filename, sizeof(llvm_filename), "%.*s.ll", (int)len, base);
+    } else {
+      snprintf(llvm_filename, sizeof(llvm_filename), "%s.ll", base);
+    }
+    llvm_f = llvm_filename;
   }
 
-  if (show_time)
+  /* ── Phase 0: Timing setup ── */
+  if (opts->show_time)
+    clock_gettime(CLOCK_MONOTONIC, &t_start);
+
+  current_input_filename = opts->in_f;
+  load_source_file(opts->in_f);
+  set_location_with_column(opts->in_f, 1, 1);
+  yyin = input_file;
+
+  if (opts->show_time)
+    clock_gettime(CLOCK_MONOTONIC, &t_file_ts);
+
+  /* ── Phase 1: Parse ── */
+  result = yyparse();
+  if (result == 0 && root)
+    inline_imports(root);
+
+  if (opts->show_time)
     clock_gettime(CLOCK_MONOTONIC, &t_parse_ts);
 
+  /* ── Phase 2: Semantic analysis → Type check → Ownership → Unused vars ── */
   if (result == 0) {
+    result = 1; /* default: failure until we reach the success path below */
     int errs = check_undefined_symbols(root);
     if (errs > 0) {
       fprintf(stderr, "Error: Found %d semantic error(s)\n", errs);
-      if (root) {
-        free_ast(root);
-      }
-      cleanup_error_handler();
-      fclose(input_file);
-      return 1;
+      goto cleanup;
     }
 
     if (typecheck_program(root) != 0) {
       fprintf(stderr, "Compilation failed with type errors\n");
-      if (root) {
-        free_ast(root);
-      }
-      cleanup_error_handler();
-      fclose(input_file);
-      return 1;
+      goto cleanup;
     }
     if (ownership_check_program(root) != 0) {
       fprintf(stderr, "Compilation failed with ownership errors\n");
-      if (root) {
-        free_ast(root);
-      }
-      cleanup_error_handler();
-      fclose(input_file);
-      return 1;
+      goto cleanup;
     }
-    SymbolTable *g_tbl = create_symbol_table(NULL);
-    int uvars = check_unused_variables(root, g_tbl);
-    destroy_symbol_table(g_tbl);
-    (void)uvars;
+
+    {
+      SymbolTable *g_tbl = create_symbol_table(NULL);
+      int uvars = check_unused_variables(root, g_tbl);
+      destroy_symbol_table(g_tbl);
+      (void)uvars;
+    }
+
     if (get_error_count() > 0) {
-      fprintf(stderr, "Compilation failed with %d error(s)\n",
-              get_error_count());
-      if (root) {
-        free_ast(root);
-      }
-      cleanup_error_handler();
-      fclose(input_file);
-      return 1;
+      fprintf(stderr, "Compilation failed with %d error(s)\n", get_error_count());
+      goto cleanup;
     }
 
-    if (show_time)
+    if (opts->show_time)
       clock_gettime(CLOCK_MONOTONIC, &t_sema_ts);
-    if (show_time)
-      t_codegen_ts = t_sema_ts; /* default = sema time if no codegen */
+    if (opts->show_time)
+      t_codegen_ts = t_sema_ts;
 
-    if (check_only) {
+    /* ── Phase 3: Check-only mode ── */
+    if (opts->check_only) {
       print_error_summary();
-      if (show_time)
-        print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                           t_codegen_ts);
-      if (root)
-        free_ast(root);
-      cleanup_error_handler();
-      fclose(input_file);
-      return get_error_count() > 0 ? 1 : 0;
+      result = (get_error_count() > 0) ? 1 : 0;
+      goto cleanup;
     }
 
+    /* ── Phase 4: Codegen ── */
 #ifndef VIXC_FRONTEND_ONLY
-    if (gen_llvm) {
-      char llvm_filename[2048];
+    if (opts->gen_llvm || opts->save_c) {
       if (!llvm_f) {
-        char *dot = strrchr(in_f, '.');
-        if (dot) {
-          size_t len = dot - in_f;
-          snprintf(llvm_filename, sizeof(llvm_filename), "%.*s.ll", (int)len,
-                   in_f);
-        } else {
-          snprintf(llvm_filename, sizeof(llvm_filename), "%s.ll", in_f);
+        fprintf(stderr, "Error: could not determine LLVM IR output path\n");
+        goto cleanup;
+      }
+
+      /* Extension check: ensure .ll suffix */
+      char llvm_buf[2048];
+      if (strstr(llvm_f, ".ll") == NULL) {
+        int written = snprintf(llvm_buf, sizeof(llvm_buf), "%s.ll", llvm_f);
+        if (written < 0 || (size_t)written >= sizeof(llvm_buf)) {
+          fprintf(stderr, "Error: LLVM IR output path is too long\n");
+          goto cleanup;
         }
-        llvm_f = llvm_filename;
-      } else {
-        if (strstr(llvm_f, ".ll") == NULL) {
-          int written =
-              snprintf(llvm_filename, sizeof(llvm_filename), "%s.ll", llvm_f);
-          if (written < 0 || (size_t)written >= sizeof(llvm_filename)) {
-            fprintf(stderr, "Error: LLVM IR output path is too long\n");
-            if (root) {
-              free_ast(root);
-            }
-            cleanup_error_handler();
-            fclose(input_file);
-            return 1;
-          }
-          llvm_f = llvm_filename;
-        }
+        llvm_f = llvm_buf;
       }
 
       FILE *llvm_file = fopen(llvm_f, "w");
       if (!llvm_file) {
-        fprintf(stderr, "Error: Cannot open LLVM IR file %s for writing\n",
-                llvm_f);
-        fclose(input_file);
-        return 1;
+        fprintf(stderr, "Error: Cannot open LLVM IR file %s for writing\n", llvm_f);
+        goto cleanup;
       }
-
       llvm_emit_from_ast(root, llvm_file);
       fclose(llvm_file);
 
-      if (show_time)
+      if (opts->show_time)
         clock_gettime(CLOCK_MONOTONIC, &t_codegen_ts);
 
       if (get_error_count() > 0) {
-        fprintf(stderr, "Compilation failed with %d error(s)\n",
-                get_error_count());
+        fprintf(stderr, "Compilation failed with %d error(s)\n", get_error_count());
         remove(llvm_f);
-        if (root) {
-          free_ast(root);
-        }
-        cleanup_error_handler();
-        fclose(input_file);
-        return 1;
+        goto cleanup;
       }
 
-      if (gen_obj) {
+      /* ── .o file generation ── */
+      if (opts->gen_obj) {
         char oname[2048];
-        const char *fobj = obj_f;
+        const char *fobj = opts->obj_f;
         if (!fobj) {
-          char *dot = strrchr(in_f, '.');
+          char *dot = strrchr(opts->in_f, '.');
           if (dot) {
-            size_t len = dot - in_f;
-            snprintf(oname, sizeof(oname), "%.*s.o", (int)len, in_f);
+            size_t len = dot - opts->in_f;
+            snprintf(oname, sizeof(oname), "%.*s.o", (int)len, opts->in_f);
           } else {
-            snprintf(oname, sizeof(oname), "%s.o", in_f);
+            snprintf(oname, sizeof(oname), "%s.o", opts->in_f);
           }
           fobj = oname;
         } else if (strstr(fobj, ".o") == NULL) {
           snprintf(oname, sizeof(oname), "%s.o", fobj);
           fobj = oname;
         }
+
         const char *llc_err = NULL;
         if (!llc_compile_to_object(llvm_f, fobj, eff_t ? eff_t : "", bare,
-                                   opt_level, &llc_err)) {
-          fprintf(stderr,
-                  "Error: Failed to compile LLVM IR to object file via Llc");
-          if (llc_err && llc_err[0] != '\0') {
-            fprintf(stderr, ": %s", llc_err);
-          }
+                                   opts->opt_level, &llc_err)) {
+          fprintf(stderr, "Error: Failed to compile LLVM IR to object file via Llc");
+          if (llc_err && llc_err[0] != '\0') fprintf(stderr, ": %s", llc_err);
           fprintf(stderr, "\n");
-          fclose(input_file);
-          return 1;
+          goto cleanup;
         }
 
-        if (!save_c) {
+        if (!opts->save_c) {
           remove(llvm_f);
-          if (root) {
-            free_ast(root);
-          }
-          fclose(input_file);
-          if (show_time)
-            print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                               t_codegen_ts);
-          print_error_summary();
-          return 0;
+          result = 0;
+          goto done;
         }
       }
-      if (gen_asm) {
+
+      /* ── Assembly (.s) generation ── */
+      if (opts->gen_asm) {
         char oname[2048];
-        const char *fasm = asm_f;
+        const char *fasm = opts->asm_f;
         if (!fasm) {
-          char *dot = strrchr(in_f, '.');
+          char *dot = strrchr(opts->in_f, '.');
           if (dot) {
-            size_t len = dot - in_f;
-            snprintf(oname, sizeof(oname), "%.*s.s", (int)len, in_f);
+            size_t len = dot - opts->in_f;
+            snprintf(oname, sizeof(oname), "%.*s.s", (int)len, opts->in_f);
           } else {
-            snprintf(oname, sizeof(oname), "%s.s", in_f);
+            snprintf(oname, sizeof(oname), "%s.s", opts->in_f);
           }
           fasm = oname;
         } else if (strstr(fasm, ".s") == NULL) {
@@ -659,36 +508,24 @@ int main(int argc, char **argv) {
 
         const char *llc_err = NULL;
         if (!llc_compile_to_assembly(llvm_f, fasm, eff_t ? eff_t : "", bare,
-                                     opt_level, &llc_err)) {
-          fprintf(stderr,
-                  "Error: Failed to compile LLVM IR to assembly via Llc");
-          if (llc_err && llc_err[0] != '\0') {
-            fprintf(stderr, ": %s", llc_err);
-          }
+                                     opts->opt_level, &llc_err)) {
+          fprintf(stderr, "Error: Failed to compile LLVM IR to assembly via Llc");
+          if (llc_err && llc_err[0] != '\0') fprintf(stderr, ": %s", llc_err);
           fprintf(stderr, "\n");
-          fclose(input_file);
-          return 1;
+          goto cleanup;
         }
-
         remove(llvm_f);
-
-        if (root) {
-          free_ast(root);
-        }
-        fclose(input_file);
-        if (show_time)
-          print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                             t_codegen_ts);
-        print_error_summary();
-        return 0;
+        result = 0;
+        goto done;
       }
-      if (out_f && save_c) {
+
+      /* ── Link to executable ── */
+      if (opts->out_f && opts->save_c) {
         const char *ls = NULL;
         if (bare) {
           ls = "linker.ld";
-          if (!vix_file_readable(ls) && vix_file_readable("src/linker.ld")) {
+          if (!vix_file_readable(ls) && vix_file_readable("src/linker.ld"))
             ls = "src/linker.ld";
-          }
         }
 
         char obj_file[2048];
@@ -702,121 +539,100 @@ int main(int argc, char **argv) {
             if (written < 0 || (size_t)written >= sizeof(obj_file)) {
               fprintf(stderr, "Error: object output path is too long\n");
               remove(llvm_f);
-              fclose(input_file);
-              return 1;
+              goto cleanup;
             }
           }
         }
 
         const char *llc_err = NULL;
-        if (!llc_compile_to_object(llvm_f, obj_file, eff_t ? eff_t : "", bare,
-                                   opt_level, &llc_err)) {
-          fprintf(stderr,
-                  "Error: Failed to compile LLVM IR to object file via Llc");
-          if (llc_err && llc_err[0] != '\0') {
-            fprintf(stderr, ": %s", llc_err);
-          }
+        if (!llc_compile_to_object(llvm_f, obj_file, eff_t ? eff_t : "",
+                                   bare, opts->opt_level, &llc_err)) {
+          fprintf(stderr, "Error: Failed to compile LLVM IR to object file via Llc");
+          if (llc_err && llc_err[0] != '\0') fprintf(stderr, ": %s", llc_err);
           fprintf(stderr, "\n");
           remove(llvm_f);
-          fclose(input_file);
-          return 1;
+          goto cleanup;
         }
 
         const char *link_err = NULL;
         VixLinkOptions link_opts = {
-            .target_triple = eff_t,
-            .bare_mode = bare,
-            .linker_script = ls,
-            .static_link = bare || static_link,
-            .entry_point = bare ? "_start" : NULL,
-            .libc_dir = find_bundled_libc(),
-            .lib_paths = lib_path_count > 0 ? (const char **)lib_paths : NULL,
-            .lib_path_count = lib_path_count,
-            .extra_libs = extra_lib_count > 0 ? (const char **)extra_libs : NULL,
-            .extra_lib_count = extra_lib_count,
+          .target_triple = eff_t,
+          .bare_mode = bare,
+          .linker_script = ls,
+          .static_link = bare || opts->static_link,
+          .entry_point = bare ? "_start" : NULL,
+          .libc_dir = find_bundled_libc(),
+          .lib_paths = opts->lib_path_count > 0 ? (const char **)opts->lib_paths : NULL,
+          .lib_path_count = opts->lib_path_count,
+          .extra_libs = opts->extra_lib_count > 0 ? (const char **)opts->extra_libs : NULL,
+          .extra_lib_count = opts->extra_lib_count,
         };
-        if (!vix_link(obj_file, out_f, &link_opts, &link_err)) {
+        if (!vix_link(obj_file, opts->out_f, &link_opts, &link_err)) {
           fprintf(stderr, "Error: Failed to link object file to executable");
-          if (link_err && link_err[0] != '\0') {
-            fprintf(stderr, ":\n%s", link_err);
-          }
+          if (link_err && link_err[0] != '\0') fprintf(stderr, ":\n%s", link_err);
           fprintf(stderr, "\n");
           remove(llvm_f);
           remove(obj_file);
-          fclose(input_file);
-          return 1;
+          goto cleanup;
         }
-
         remove(llvm_f);
         remove(obj_file);
+        result = 0;
+        goto done;
       }
 
-      if (root) {
-        free_ast(root);
-      }
-      fclose(input_file);
-      if (show_time)
-        print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                           t_codegen_ts);
-      print_error_summary();
-      return 0;
+      result = 0;
+      goto done;
     }
+#endif
 
-    if (out_ast) {
+    if (opts->out_ast) {
       printf("===========================AST=======================\n");
       print_ast(root, 0);
       printf("===================================================\n");
-      if (root)
-        free_ast(root);
-      fclose(input_file);
-      if (show_time)
-        print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                           t_codegen_ts);
-      print_error_summary();
-      return 0;
+      result = 0;
+      goto done;
     }
 
-    if (out_llvm) {
+    if (opts->out_llvm) {
+#ifndef VIXC_FRONTEND_ONLY
       printf("=========================LLVM IR===================\n");
       llvm_emit_from_ast(root, stdout);
       printf("===================================================\n");
-      if (root)
-        free_ast(root);
-      fclose(input_file);
-      if (show_time)
-        print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                           t_codegen_ts);
-      print_error_summary();
-      return 0;
-    }
 #else
-    if (root) {
-      free_ast(root);
-    }
-    fclose(input_file);
-    if (show_time)
-      print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts,
-                         t_codegen_ts);
-    print_error_summary();
-    return 0;
+      fprintf(stderr, "Error: LLVM output not available (frontend-only build)\n");
 #endif
-  } else {
-    if (get_error_count() == 0) {
-      const char *fname =
-          current_input_filename ? current_input_filename : "unknown";
-      report_syntax_error_with_location("parsing failed due to syntax errors",
-                                        fname, 1);
+      result = 0;
+      goto done;
     }
+
+#ifndef VIXC_FRONTEND_ONLY
+    result = 0;
+    goto done;
+#endif
   }
 
-  if (root) {
-    free_ast(root);
+  if (get_error_count() == 0 && result != 0) {
+    const char *fname = current_input_filename ? current_input_filename : "unknown";
+    report_syntax_error_with_location("parsing failed due to syntax errors", fname, 1);
   }
+  result = 1;
+
+/* ── Unified cleanup ── */
+cleanup:
+done:
+  if (opts->show_time && result == 0)
+    print_timing_table(t_start, t_file_ts, t_parse_ts, t_sema_ts, t_codegen_ts);
+  print_error_summary();
+  if (root) { free_ast(root); root = NULL; }
   cleanup_error_handler();
-  fclose(input_file);
+  if (free_out_f && opts->out_f) { free(opts->out_f); }
   return result;
 }
 
+/* ==================================================================
+ * Timing display
+ * ================================================================== */
 static void print_timing_table(struct timespec t_start, struct timespec t_file,
                                struct timespec t_parse, struct timespec t_sema,
                                struct timespec t_codegen) {
@@ -843,4 +659,48 @@ static void print_timing_table(struct timespec t_start, struct timespec t_file,
   fprintf(stderr,
           "\033[36m  ────────────────────────────────────────────\033[0m\n");
   fprintf(stderr, "  Total       %9.2f ms\n", ms_total);
+}
+
+/* ==================================================================
+ * Find bundled libc directory (relative to compiler executable)
+ * ================================================================== */
+static const char *find_bundled_libc(void) {
+  static char libc_path[4096];
+  char exe_dir[4096];
+
+#ifdef _WIN32
+  DWORD len = GetModuleFileNameA(NULL, exe_dir, sizeof(exe_dir));
+  if (len == 0 || len >= sizeof(exe_dir)) return NULL;
+  char *last_sep = strrchr(exe_dir, '\\');
+  if (!last_sep) last_sep = strrchr(exe_dir, '/');
+  if (last_sep) *last_sep = '\0';
+#else
+  ssize_t len = readlink("/proc/self/exe", exe_dir, sizeof(exe_dir) - 1);
+  if (len <= 0) return NULL;
+  exe_dir[len] = '\0';
+  char *last_sep = strrchr(exe_dir, '/');
+  if (last_sep) *last_sep = '\0';
+#endif
+
+  static const char *const suffixes[] = {
+#ifdef _WIN32
+      "\\..\\libc", "\\libc",
+#else
+      "/../libc", "/libc",
+#endif
+      NULL};
+
+  for (const char *const *s = suffixes; *s; ++s) {
+    snprintf(libc_path, sizeof(libc_path), "%s%s", exe_dir, *s);
+#ifdef _WIN32
+    DWORD attr = GetFileAttributesA(libc_path);
+    if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY))
+      return libc_path;
+#else
+    struct stat st;
+    if (stat(libc_path, &st) == 0 && S_ISDIR(st.st_mode))
+      return libc_path;
+#endif
+  }
+  return NULL;
 }

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -99,6 +99,38 @@ static int is_builtin_union_ctor_name(const char* name) {
            strcmp(name, "Ok") == 0 || strcmp(name, "Err") == 0;
 }
 
+/**
+ * @brief Reset all parser global state — must be called before each compilation
+ *        to prevent state leakage across runs (e.g. when the compiler is used
+ *        as a library via VIXC_FRONTEND_ONLY).
+ */
+void vix_reset_parser_state(void) {
+    for (int i = 0; i < g_adt_def_count; i++) {
+        free(g_adt_defs[i].name);
+        g_adt_defs[i].name = NULL;
+        if (g_adt_defs[i].ctors) {
+            for (int j = 0; j < g_adt_defs[i].ctor_count; j++) {
+                free(g_adt_defs[i].ctors[j].name);
+                g_adt_defs[i].ctors[j].name = NULL;
+                /* payload_type_node is owned by AST, not freed here */
+            }
+            free(g_adt_defs[i].ctors);
+            g_adt_defs[i].ctors = NULL;
+        }
+    }
+    g_adt_def_count = 0;
+    g_adt_payload_type_count = 0;
+    for (int i = 0; i < g_impl_method_count; i++) {
+        free(g_impl_methods[i].type_name);
+        g_impl_methods[i].type_name = NULL;
+        free(g_impl_methods[i].method_name);
+        g_impl_methods[i].method_name = NULL;
+        free(g_impl_methods[i].func_name);
+        g_impl_methods[i].func_name = NULL;
+    }
+    g_impl_method_count = 0;
+}
+
 static int find_adt_def_index(const char* name) {
     if (!name) return -1;
     for (int i = 0; i < g_adt_def_count; i++) {

--- a/src/semantic/semantic.c
+++ b/src/semantic/semantic.c
@@ -388,11 +388,14 @@ static int is_lvalue_mutable(ASTNode* node, SymbolTable* table) {
     
     if (node->type == AST_IDENTIFIER) {
         Symbol* sym = lookup_symbol(table, node->data.identifier.name);
-        if (sym && sym->is_mutable_pointer) {
-            return 1;
+        if (sym) {
+            return sym->is_mutable_pointer;
         }
     } else if (node->type == AST_UNARYOP && node->data.unaryop.op == OP_DEREF) {
         return is_lvalue_mutable(node->data.unaryop.expr, table);
+    } else if (node->type == AST_MEMBER_ACCESS) {
+        /* @ptr.x = val : check if the underlying object ptr is mutable */
+        return is_lvalue_mutable(node->data.member_access.object, table);
     } else if (node->type == AST_INDEX) {
         return is_lvalue_mutable(node->data.index.target, table);
     }

--- a/tests/ownership_tests.py
+++ b/tests/ownership_tests.py
@@ -1,0 +1,453 @@
+"""
+Comprehensive Ownership & Borrow Checker Tests
+
+Tests the ownership checker (field-level borrows, NLL, mut ptr, move semantics)
+by compiling .vix files and checking for expected pass/fail outcomes.
+
+Each test compiles a small Vix source with --check and asserts:
+  - Good tests:  returncode == 0 (no errors)
+  - Error tests: returncode != 0 (ownership violation detected)
+"""
+
+import pytest
+from pathlib import Path
+from helpers import compile_source, ROOT
+
+# ──────────────────────────────────────────────
+#  FIELD-LEVEL BORROW PRECISION
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestFieldLevelBorrows:
+
+    def test_shared_borrow_field_other_readable(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let p = Point { x: 10, y: 20 }
+    let r = ref p.x
+    print(p.y)
+    @r
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0, f"stderr: {res.stderr}"
+
+    def test_mut_borrow_field_other_writable(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 10, y: 20 }
+    let r = mut ref p.x
+    p.y = 30
+    print(@r)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0, f"stderr: {res.stderr}"
+
+    def test_two_shared_borrows_diff_fields(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let p = Point { x: 10, y: 20 }
+    let rx = ref p.x
+    let ry = ref p.y
+    print(@rx + @ry)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+    def test_use_mut_borrowed_field_rejected(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 10, y: 20 }
+    let r = mut ref p.x
+    print(p.x)
+    @r
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrowed" in res.stderr
+
+    def test_assign_to_mut_borrowed_field_rejected(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 10, y: 20 }
+    let r = mut ref p.x
+    p.x = 30
+    @r
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrowed" in res.stderr
+
+    def test_assign_to_shared_borrowed_field_rejected(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 10, y: 20 }
+    let r = ref p.x
+    p.x = 30
+    @r
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrowed" in res.stderr
+
+    def test_move_while_field_borrowed_rejected(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let p = Point { x: 10, y: 20 }
+    let r = ref p.x
+    let q = p
+    print(@r)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrowed" in res.stderr
+
+
+# ──────────────────────────────────────────────
+#  NLL (NON-LEXICAL LIFETIMES)
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestNLL:
+
+    def test_nll_shared_read_after_last_use(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let x = 42
+    let r = ref x
+    print(@r)
+    print(x)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0, f"stderr: {res.stderr}"
+
+    def test_nll_mut_assign_after_last_use(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let r = mut ref x
+    print(@r)
+    x = 30
+    print(x)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0, f"stderr: {res.stderr}"
+
+    def test_nll_field_use_after_last_use(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 1, y: 2 }
+    let r = ref p.x
+    print(@r)
+    p.x = 42
+    print(p.x + p.y)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+    def test_nll_two_borrowers_one_dies_early(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let r1 = ref x
+    print(@r1)
+    x = 20
+    let r2 = ref x
+    print(@r2)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+    def test_use_while_borrow_still_alive_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 42
+    let r = mut ref x
+    print(x)
+    print(@r)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrowed" in res.stderr
+
+
+# ──────────────────────────────────────────────
+#  MUTABLE BORROW + POINTER WRITE
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestMutablePtrWrite:
+
+    def test_mut_ptr_write_simple(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let mut ptr = mut ref x
+    @ptr = 20
+    return @ptr
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0, f"stderr: {res.stderr}"
+
+    def test_mut_ptr_write_then_reborrow(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let mut ptr = mut ref x
+    @ptr = 99
+    print(@ptr)
+    x = 100
+    print(x)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+    def test_write_through_shared_borrow_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let ptr = ref x
+    let mut ptr2 = ptr
+    @ptr2 = 20
+    return @ptr
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "immutable pointer" in res.stderr or "borrowed" in res.stderr
+
+
+# ──────────────────────────────────────────────
+#  MOVE SEMANTICS
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestMoveSemantics:
+
+    def test_copy_type_not_moved(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let x = 10
+    let y = x
+    print(x + y)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+    def test_use_after_move_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let s = [1, 2, 3]
+    let t = s
+    print(s[0])
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "use of moved value" in res.stderr
+
+    def test_use_after_move_call_rejected(self, compiler, tmp_path):
+        src = """
+fn take(xs: [i32]): i32 { xs[0] }
+fn main(): i32 {
+    let arr = [1, 2, 3]
+    take(arr)
+    print(arr[0])
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "use of moved value" in res.stderr
+
+
+# ──────────────────────────────────────────────
+#  BORROW CONFLICTS
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestBorrowConflicts:
+
+    def test_mut_borrow_twice_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut v = 10
+    let r1 = mut ref v
+    let r2 = mut ref v
+    print(@r1)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrow" in res.stderr.lower()
+
+    def test_imm_borrow_while_mut_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut y = 99
+    let ry = mut ref y
+    let ry2 = ref y
+    print(@ry)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrow" in res.stderr.lower()
+
+    def test_assign_while_mut_borrowed_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let r = mut ref x
+    x = 20
+    print(@r)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrowed" in res.stderr.lower()
+
+    def test_move_while_borrowed_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let s = [1, 2, 3]
+    let r = ref s[0]
+    let t = s
+    print(@r)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "cannot move" in res.stderr
+
+    def test_borrow_moved_value_rejected(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let s = [1, 2, 3]
+    let t = s
+    let r = ref s
+    print(@r)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "moved" in res.stderr
+
+    def test_return_local_ref_rejected(self, compiler, tmp_path):
+        src = """
+fn bad(): ref i32 { let z = 1; return ref z }
+fn main(): i32 { print(bad()); return 0 }"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "return reference" in res.stderr
+
+
+# ──────────────────────────────────────────────
+#  IF/ELSE BRANCH MERGE
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestIfElseBranchMerge:
+
+    def test_field_borrow_merge_if_else(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 1, y: 2 }
+    let cond = 1 < 2
+    if (cond) {
+        let r = ref p.x
+        print(@r)
+    } else {
+        let r = ref p.y
+        print(@r)
+    }
+    p.x = 10
+    p.y = 20
+    print(p.x + p.y)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0, f"stderr: {res.stderr}"
+
+    def test_nll_after_if_else(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut x = 10
+    let r = ref x
+    print(@r)
+    if (1 < 2) {
+        x = 20
+    } else {
+        x = 30
+    }
+    print(x)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+
+# ──────────────────────────────────────────────
+#  WHILE LOOP
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestWhileLoop:
+
+    def test_while_loop_inner_borrow(self, compiler, tmp_path):
+        src = """
+fn main(): i32 {
+    let mut sum = 0
+    let mut i = 0
+    while (i < 3) {
+        let r = ref sum
+        print(@r)
+        i = i + 1
+    }
+    print(sum)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode == 0
+
+
+# ──────────────────────────────────────────────
+#  OVERLAPPING FIELD BORROWS
+# ──────────────────────────────────────────────
+
+@pytest.mark.ownership
+class TestOverlappingFieldBorrows:
+
+    def test_overlapping_field_mut_rejected(self, compiler, tmp_path):
+        src = """
+type Point = struct { x: i32, y: i32 }
+fn main(): i32 {
+    let mut p = Point { x: 1, y: 2 }
+    let rx = mut ref p.x
+    let rx2 = mut ref p.x
+    print(@rx)
+    return 0
+}"""
+        res, _ = compile_source(compiler, src, tmp_path)
+        assert res.returncode != 0
+        assert "borrow" in res.stderr.lower()


### PR DESCRIPTION
- Fix ownership checker: mutable borrow flag no longer blocks indirect writes
  through the borrow (the flag grants exclusive access, not prohibits it).
  Only shared borrow now blocks indirect writes. Added field-level borrow
  handling for indirect assignments.
- Fix semantic checker: `is_lvalue_mutable` now correctly recurses into
  `AST_MEMBER_ACCESS` to determine mutability of `@ptr.x = val` assignments.
- Refactor main.c: extract `VixOptions` struct, split linker/compiler
  pipelines, add `-l` flag, clean up error handling and deduplicate code.
- Add `vix_reset_parser_state()` to clear global parser state (ADT defs,
  impl methods) between compilations, preventing state leakage.
- Add `vix_source_get_attrs()` API for source attribute detection.
- Add comprehensive ownership tests: field-level borrows, NLL, mutable
  pointer writes, move semantics, branch merge, overlapping field borrows.
- Add example `.vix` files for good and error ownership cases.

Co-authored-by: Claude <claude@anthropic.com>