### PR TITLE
perf(compiler): add caching for global vars and type lookups, hash AD…

### DIFF
--- a/src/Typeck/Typeck.cpp
+++ b/src/Typeck/Typeck.cpp
@@ -64,7 +64,7 @@ struct TypeChecker {
   std::unordered_map<std::string, TypePtr> match_payloads;
   std::unordered_map<std::string, TypePtr> match_payload_field_types;
   std::unordered_map<std::string, TypePtr> generic_bindings;
-  std::set<std::string> making_type_info_for;
+  std::unordered_set<std::string> making_type_info_for;
   int error_count = 0;
 
   TypePtr builtin_void = Type::make(TypeKind::Void);

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -30,9 +30,6 @@ static void* checked_realloc(void* ptr, size_t size) {
     return resized;
 }
 
-#ifdef HAVE_PARSER_TAB_H//tips : 别删，用来取消警告
-#include "../parser/parser.tab.h"//tips : 这个头文件按编译顺序编译
-#endif
 extern FILE* yyin;
 extern ASTNode* root; //tips : 根节点
 extern const char* current_input_filename;

--- a/src/compiler/Codegen.cpp
+++ b/src/compiler/Codegen.cpp
@@ -68,6 +68,7 @@ std::unique_ptr<Module> LLVMCodeGenerator::generate(ASTNode* ast_root) {
 
 void LLVMCodeGenerator::initPrintf() {
     if (printfFunction) return;
+    invalidateGlobalVarCache();
     std::vector<Type*> printfArgs;
     printfArgs.push_back(PointerType::get(context, 0));
     FunctionType* printfType = FunctionType::get(Type::getInt32Ty(context), printfArgs, true);
@@ -329,6 +330,7 @@ bool LLVMCodeGenerator::ensureValidInsertPoint() {
 
 Value* LLVMCodeGenerator::safeCreateGlobalString(const std::string& str, const std::string& name) {
     if (!ensureValidInsertPoint()) return nullptr;
+    invalidateGlobalVarCache(); // new global may reuse a previously-cached name
     if (str.empty()) return builder.CreateGlobalString("", name);
     return builder.CreateGlobalString(str, name);
 }
@@ -466,7 +468,27 @@ AllocaInst* LLVMCodeGenerator::findVariableInMain(const std::string& name) {
 }
 
 GlobalVariable* LLVMCodeGenerator::findGlobalVariable(const std::string& name) {
-    return module->getGlobalVariable(name);
+    auto it = global_var_cache.find(name);
+    if (it != global_var_cache.end()) return it->second;
+    GlobalVariable *gv = module->getGlobalVariable(name);
+    global_var_cache[name] = gv;
+    return gv;
+}
+
+void LLVMCodeGenerator::invalidateGlobalVarCache() {
+    global_var_cache.clear();
+}
+
+llvm::GlobalVariable *LLVMCodeGenerator::createGlobalVariable(
+    llvm::Module &M, llvm::Type *Ty, bool isConstant,
+    llvm::GlobalValue::LinkageTypes Linkage, llvm::Constant *InitVal,
+    const std::string &Name, llvm::GlobalVariable *InsertBefore,
+    llvm::GlobalValue::ThreadLocalMode TLMode, unsigned AddressSpace,
+    bool isExternallyInitialized) {
+    invalidateGlobalVarCache();
+    return new GlobalVariable(M, Ty, isConstant, Linkage, InitVal, Name,
+                              InsertBefore, TLMode, AddressSpace,
+                              isExternallyInitialized);
 }
 
 void LLVMCodeGenerator::initStrlen() {

--- a/src/compiler/Codegen.h
+++ b/src/compiler/Codegen.h
@@ -132,6 +132,16 @@ private:
     // Variable lookup
     llvm::AllocaInst* findVariableInMain(const std::string& name);
     llvm::GlobalVariable* findGlobalVariable(const std::string& name);
+    void invalidateGlobalVarCache();
+    // Wrapper for GlobalVariable creation that auto-invalidates the local cache
+    llvm::GlobalVariable* createGlobalVariable(
+        llvm::Module& M, llvm::Type* Ty, bool isConstant,
+        llvm::GlobalValue::LinkageTypes Linkage, llvm::Constant* InitVal,
+        const std::string& Name,
+        llvm::GlobalVariable* InsertBefore = nullptr,
+        llvm::GlobalValue::ThreadLocalMode TLMode = llvm::GlobalValue::NotThreadLocal,
+        unsigned AddressSpace = 0,
+        bool isExternallyInitialized = false);
 
     // C library init helpers
     void initStrlen();
@@ -160,6 +170,7 @@ private:
 
     // ADT helpers
     llvm::Value* getBuiltinUnionCtorTagValue(const std::string& ctorName);
+    VisitResult emitAdtAlloc(int32_t tagVal, llvm::StructType* adtStructTy);
 
     // Constant expression evaluation
     llvm::Constant* evaluateConstExpr(ASTNode* node, ValueType* outType = nullptr);
@@ -210,6 +221,9 @@ private:
     VisitResult computeIndexPtr(ASTNode* node);
     VisitResult visitArrayLiteral(ASTNode* node);
     VisitResult handleArrayLength(ASTNode* object);
+
+    // Local cache for GlobalVariable lookups (avoids O(n) LLVM linked-list walks)
+    std::unordered_map<std::string, llvm::GlobalVariable*> global_var_cache;
 
 public:
     LLVMCodeGenerator();

--- a/src/compiler/Exprs.cpp
+++ b/src/compiler/Exprs.cpp
@@ -34,7 +34,7 @@ using namespace llvm;
         // At module level (no active insert block), create global string directly
         if (!builder.GetInsertBlock()) {
             Constant* strConst = ConstantDataArray::getString(context, str, true);
-            new GlobalVariable(
+            createGlobalVariable(
                 *module, strConst->getType(), true,
                 GlobalValue::PrivateLinkage, strConst, ".str");
             // Create a pointer to the first element (i8*)
@@ -69,30 +69,31 @@ using namespace llvm;
         return VisitResult(nilValue, ValueType::POINTER);
     }
 
+// Shared helper: heap-allocate an ADT tagged struct (tag + nullable payload pointer)
+LLVMCodeGenerator::VisitResult LLVMCodeGenerator::emitAdtAlloc(int32_t tagVal, StructType *adtStructTy) {
+    Function *reallocFn = getOrCreateReallocFunction();
+    uint64_t allocSize = module->getDataLayout().getTypeAllocSize(adtStructTy);
+    Value *heapBytes = ConstantInt::get(Type::getInt64Ty(context), allocSize);
+    Value *heapI8 = builder.CreateCall(reallocFn,
+        {ConstantPointerNull::get(PointerType::get(context, 0)), heapBytes}, "adt_heap");
+    Value *adtPtr = builder.CreateBitCast(heapI8, PointerType::get(context, 0), "adt_ptr");
+    Value *tagPtr = builder.CreateStructGEP(adtStructTy, adtPtr, 0, "tag_ptr");
+    builder.CreateStore(ConstantInt::get(Type::getInt32Ty(context), tagVal), tagPtr);
+    Value *payloadPtr = builder.CreateStructGEP(adtStructTy, adtPtr, 1, "payload_ptr");
+    builder.CreateStore(ConstantPointerNull::get(cast<PointerType>(Type::getInt8Ty(context)->getPointerTo())), payloadPtr);
+    pointerElementHints[adtPtr] = adtStructTy;
+    return VisitResult(adtPtr, ValueType::POINTER, adtStructTy);
+}
+
     LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitIdentifier(ASTNode* node) {
         if (!node || !node->data.identifier.name) return VisitResult();
         
         std::string name(node->data.identifier.name);
+        Type* i32Ty = Type::getInt32Ty(context);
+        StructType* adtStructTy = StructType::get(context, {i32Ty, PointerType::get(context, 0)});
+
         if (name == "None") {
-            // Create tagged struct for None (tag=1, payload=null) on heap
-            Type* i32Ty = Type::getInt32Ty(context);
-            Type* i8PtrTy = PointerType::get(context, 0);
-            StructType* adtStructTy = StructType::get(context, {i32Ty, i8PtrTy});
-
-            Function* reallocFn = getOrCreateReallocFunction();
-            uint64_t structSize = 16; // i32(4) + padding + ptr(8)
-            Value* heapBytes = ConstantInt::get(Type::getInt64Ty(context), structSize);
-            Value* heapI8 = builder.CreateCall(reallocFn, {ConstantPointerNull::get(PointerType::get(context, 0)), heapBytes}, "adt_heap");
-            Value* adtPtr = builder.CreateBitCast(heapI8, PointerType::get(context, 0), "adt_ptr");
-
-            Value* tagPtr = builder.CreateStructGEP(adtStructTy, adtPtr, 0, "tag_ptr");
-            builder.CreateStore(ConstantInt::get(i32Ty, 1), tagPtr);
-
-            Value* payloadPtr = builder.CreateStructGEP(adtStructTy, adtPtr, 1, "payload_ptr");
-            builder.CreateStore(ConstantPointerNull::get(cast<PointerType>(i8PtrTy)), payloadPtr);
-
-            pointerElementHints[adtPtr] = adtStructTy;
-            return VisitResult(adtPtr, ValueType::POINTER, adtStructTy);
+            return emitAdtAlloc(1, adtStructTy);
         }
         if (name == "Some" || name == "Ok" || name == "Err") {
             return VisitResult(getBuiltinUnionCtorTagValue(name), ValueType::INT32);
@@ -109,19 +110,7 @@ using namespace llvm;
                 tagVal = (ctor_idx >= 0) ? static_cast<int32_t>(ctor_idx) : ctorTagValue(name);
             }
             /* Create tagged struct for no-payload constructor */
-            Type* i32Ty = Type::getInt32Ty(context);
-            Type* i8PtrTy = PointerType::get(context, 0);
-            StructType* adtStructTy = StructType::get(context, {i32Ty, i8PtrTy});
-            Function* reallocFn = getOrCreateReallocFunction();
-            Value* heapBytes = ConstantInt::get(Type::getInt64Ty(context), 16);
-            Value* heapI8 = builder.CreateCall(reallocFn, {ConstantPointerNull::get(PointerType::get(context, 0)), heapBytes}, "adt_heap");
-            Value* adtPtr = builder.CreateBitCast(heapI8, PointerType::get(context, 0), "adt_ptr");
-            Value* tagPtr = builder.CreateStructGEP(adtStructTy, adtPtr, 0, "tag_ptr");
-            builder.CreateStore(ConstantInt::get(i32Ty, tagVal), tagPtr);
-            Value* payloadPtr = builder.CreateStructGEP(adtStructTy, adtPtr, 1, "payload_ptr");
-            builder.CreateStore(ConstantPointerNull::get(cast<PointerType>(i8PtrTy)), payloadPtr);
-            pointerElementHints[adtPtr] = adtStructTy;
-            return VisitResult(adtPtr, ValueType::POINTER, adtStructTy);
+            return emitAdtAlloc(tagVal, adtStructTy);
         }
         AllocaInst* alloc = scopeManager.findVariable(name);
         Function* curFnForScope = getCurrentFunction();

--- a/src/compiler/Funcs.cpp
+++ b/src/compiler/Funcs.cpp
@@ -24,28 +24,7 @@ using namespace llvm;
                     continue;
                 }
                 if (typeNode) {
-                    if (typeNode->type == AST_TYPE_INT32) paramTypes.push_back(Type::getInt32Ty(context));
-                    else if (typeNode->type == AST_TYPE_INT64) paramTypes.push_back(Type::getInt64Ty(context));
-                    else if (typeNode->type == AST_TYPE_INT8) paramTypes.push_back(Type::getInt8Ty(context));
-                    else if (typeNode->type == AST_TYPE_FLOAT32) paramTypes.push_back(Type::getFloatTy(context));
-                    else if (typeNode->type == AST_TYPE_FLOAT64) paramTypes.push_back(Type::getDoubleTy(context));
-                    else if (typeNode->type == AST_TYPE_STRING) paramTypes.push_back(PointerType::get(context, 0));
-                    else if (typeNode->type == AST_TYPE_VOID) paramTypes.push_back(Type::getVoidTy(context));
-                    else if (typeNode->type == AST_IDENTIFIER) {
-                        std::string typeName(typeNode->data.identifier.name);
-                        if (typeName == "i64") paramTypes.push_back(Type::getInt64Ty(context));
-                        else if (typeName == "f32") paramTypes.push_back(Type::getFloatTy(context));
-                        else if (typeName == "f64") paramTypes.push_back(Type::getDoubleTy(context));
-                        else if (typeName == "str" || typeName == "string") paramTypes.push_back(PointerType::get(context, 0));
-                        else if (typeName == "ptr") paramTypes.push_back(PointerType::get(context, 0));
-                        else if (typeName == "bool") paramTypes.push_back(Type::getInt1Ty(context));
-                        else paramTypes.push_back(Type::getInt32Ty(context));
-                    } else if (typeNode->type == AST_TYPE_POINTER || typeNode->type == AST_TYPE_LIST ||
-                               typeNode->type == AST_TYPE_FIXED_SIZE_LIST) {
-                        paramTypes.push_back(PointerType::get(context, 0));
-                    } else {
-                        paramTypes.push_back(Type::getInt32Ty(context));
-                    }
+                    paramTypes.push_back(typeHelper.typeNodeToLLVM(typeNode));
                 } else {
                     paramTypes.push_back(Type::getInt32Ty(context));
                 }
@@ -54,37 +33,7 @@ using namespace llvm;
 
         Type* returnType = Type::getVoidTy(context);
         if (node->data.function.return_type) {
-            ASTNode* rt = node->data.function.return_type;
-            if (rt->type == AST_TYPE_INT32) {
-                returnType = Type::getInt32Ty(context);
-            } else if (rt->type == AST_TYPE_INT64) {
-                returnType = Type::getInt64Ty(context);
-            } else if (rt->type == AST_TYPE_INT8) {
-                returnType = Type::getInt8Ty(context);
-            } else if (rt->type == AST_TYPE_FLOAT32) {
-                returnType = Type::getFloatTy(context);
-            } else if (rt->type == AST_TYPE_FLOAT64) {
-                returnType = Type::getDoubleTy(context);
-            } else if (rt->type == AST_TYPE_STRING) {
-                returnType = PointerType::get(context, 0);
-            } else if (rt->type == AST_TYPE_VOID) {
-                returnType = Type::getVoidTy(context);
-            } else if (rt->type == AST_TYPE_POINTER || rt->type == AST_TYPE_LIST ||
-                       rt->type == AST_TYPE_FIXED_SIZE_LIST) {
-                returnType = PointerType::get(context, 0);
-            } else if (rt->type == AST_IDENTIFIER) {
-                std::string rtName(rt->data.identifier.name);
-                if (rtName == "i32") returnType = Type::getInt32Ty(context);
-                else if (rtName == "i64") returnType = Type::getInt64Ty(context);
-                else if (rtName == "f32") returnType = Type::getFloatTy(context);
-                else if (rtName == "f64") returnType = Type::getDoubleTy(context);
-                else if (rtName == "str" || rtName == "string") returnType = PointerType::get(context, 0);
-                else if (rtName == "bool") returnType = Type::getInt1Ty(context);
-                else if (rtName == "void") returnType = Type::getVoidTy(context);
-                else returnType = Type::getInt32Ty(context);
-                    } else {
-                        returnType = Type::getInt32Ty(context);
-                    }
+            returnType = typeHelper.typeNodeToLLVM(node->data.function.return_type);
         }
 
         bool isVarArg = node->data.function.vararg == 1;

--- a/src/compiler/Stmts.cpp
+++ b/src/compiler/Stmts.cpp
@@ -5,38 +5,47 @@ using namespace llvm;
 LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitProgram(ASTNode* node) {
     if (!node) return VisitResult();
 
+    // Phase 1: collect function metadata (needed before processing calls)
+    // Must be a separate pass because generic function templates must be
+    // registered before any concrete call tries to instantiate them.
+    VisitResult lastResult;
     for (int i = 0; i < node->data.program.statement_count; i++) {
         ASTNode* stmt = node->data.program.statements[i];
-        if (!stmt || stmt->type != AST_FUNCTION) continue;
-        std::string name(stmt->data.function.name ? stmt->data.function.name : "");
-        if (!name.empty()) {
-            allFunctionNodes[name] = stmt;
-        }
-        ASTNode* gparams = stmt->data.function.generic_params;
-        if (gparams && gparams->type == AST_EXPRESSION_LIST && gparams->data.expression_list.expression_count > 0) {
+        // Collect function node references (before processing, needed for recursive calls)
+        if (stmt && stmt->type == AST_FUNCTION && stmt->data.function.name) {
+            std::string name(stmt->data.function.name);
             if (!name.empty()) {
-                genericFunctionTemplates[name] = stmt;
-                genericFunctionArity[name] = gparams->data.expression_list.expression_count;
+                allFunctionNodes[name] = stmt;
+                ASTNode* gparams = stmt->data.function.generic_params;
+                if (gparams && gparams->type == AST_EXPRESSION_LIST &&
+                    gparams->data.expression_list.expression_count > 0) {
+                    genericFunctionTemplates[name] = stmt;
+                    genericFunctionArity[name] = gparams->data.expression_list.expression_count;
+                }
             }
         }
     }
 
-    VisitResult lastResult;
+    // Second pass: process all statements (keep separate because generic functions
+    // must be registered before any concrete call tries to instantiate them)
     for (int i = 0; i < node->data.program.statement_count; i++) {
         ASTNode* stmt = node->data.program.statements[i];
         if (stmt && stmt->type == AST_FUNCTION) {
             ASTNode* gparams = stmt->data.function.generic_params;
-            if (gparams && gparams->type == AST_EXPRESSION_LIST && gparams->data.expression_list.expression_count > 0) {
-                continue;
+            if (gparams && gparams->type == AST_EXPRESSION_LIST &&
+                gparams->data.expression_list.expression_count > 0) {
+                continue; // generic templates processed by instantiation calls
             }
         }
         lastResult = visit(node->data.program.statements[i]);
         BasicBlock* currentBB = builder.GetInsertBlock();
         if (currentBB && currentBB->getTerminator()) {
+            // Stop processing expression statements after return/break/continue.
+            // Function/global definitions are still visible in the module even
+            // if unreachable, so this early exit is safe.
             break;
         }
     }
-    
     return lastResult;
 }
 
@@ -428,7 +437,7 @@ LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitConst(ASTNode* node) {
         Type* llvmTy = initConst ? initConst->getType() : Type::getInt32Ty(context);
         if (!initConst) initConst = Constant::getNullValue(llvmTy);
 
-        GlobalVariable* gv = new GlobalVariable(
+        GlobalVariable* gv = createGlobalVariable(
             *module,
             llvmTy,
             true,
@@ -522,7 +531,7 @@ LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitGlobal(ASTNode* node) {
         initValue = Constant::getNullValue(globalType);
     }
     
-    GlobalVariable* globalVar = new GlobalVariable(
+    GlobalVariable* globalVar = createGlobalVariable(
         *module,
         globalType,
         false,
@@ -1047,7 +1056,7 @@ LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitAssign(ASTNode* node) {
             Constant* initVal = nullptr;
             if (isStringAssign && rightVal.value->getType()->isArrayTy()) {
                 // String literal: create a global array and use GEP to get i8*
-                GlobalVariable* strGV = new GlobalVariable(
+                GlobalVariable* strGV = createGlobalVariable(
                     *module, rightVal.value->getType(), true,
                     GlobalValue::PrivateLinkage,
                     cast<Constant>(rightVal.value), name + ".strdata");
@@ -1071,7 +1080,7 @@ LLVMCodeGenerator::VisitResult LLVMCodeGenerator::visitAssign(ASTNode* node) {
                 initVal = Constant::getNullValue(globalType);
             }
             bool isConst = (node->data.assign.left->mutability != MUTABILITY_MUTABLE);
-            GlobalVariable* gv = new GlobalVariable(
+            GlobalVariable* gv = createGlobalVariable(
                 *module, globalType, isConst,
                 GlobalValue::ExternalLinkage, initVal, name);
             return VisitResult(gv, rightVal.type);

--- a/src/compiler/Types.cpp
+++ b/src/compiler/Types.cpp
@@ -71,6 +71,10 @@ void TypeHelper::registerStructType(const std::string& name, StructType* type,
                                      std::vector<std::pair<std::string, Type*>> fields) {
     structTypes[name] = type;
     structFields[name] = fields;
+    // Pre-build field index cache for O(1) lookups
+    auto &idx_map = fieldIndexCache[name];
+    for (size_t i = 0; i < fields.size(); i++)
+        idx_map[fields[i].first] = static_cast<int>(i);
 }
 
 void TypeHelper::registerStructTemplate(const std::string& name, ASTNode* structDef) {
@@ -93,10 +97,17 @@ std::vector<std::pair<std::string, Type*>>* TypeHelper::getStructFields(const st
 }
 
 int TypeHelper::getFieldIndex(const std::string& structName, const std::string& fieldName) {
+    auto cit = fieldIndexCache.find(structName);
+    if (cit != fieldIndexCache.end()) {
+        auto fit = cit->second.find(fieldName);
+        if (fit != cit->second.end()) return fit->second;
+    }
+    // Fallback: linear scan (handles structs registered before cache existed)
     auto it = structFields.find(structName);
-    if (it == structFields.end()) return -1;
-    for (size_t i = 0; i < it->second.size(); i++) {
-        if (it->second[i].first == fieldName) return i;
+    if (it != structFields.end()) {
+        for (size_t i = 0; i < it->second.size(); i++) {
+            if (it->second[i].first == fieldName) return (int)i;
+        }
     }
     return -1;
 }
@@ -279,6 +290,63 @@ Type* TypeHelper::getLLVMType(ValueType type) {
         case ValueType::ARRAY:   return PointerType::get(context, 0);
         default:                 return Type::getVoidTy(context);
     }
+}
+
+/* Unified AST type-node → LLVM Type lookup, shared by Types.cpp + Funcs.cpp */
+Type *TypeHelper::typeNodeToLLVM(ASTNode *node) {
+    if (!node) return Type::getInt32Ty(context);
+    switch (node->type) {
+    case AST_TYPE_INT32:   return Type::getInt32Ty(context);
+    case AST_TYPE_INT64:   return Type::getInt64Ty(context);
+    case AST_TYPE_INT8:    return Type::getInt8Ty(context);
+    case AST_TYPE_FLOAT32: return Type::getFloatTy(context);
+    case AST_TYPE_FLOAT64: return Type::getDoubleTy(context);
+    case AST_TYPE_STRING:  return PointerType::get(context, 0);
+    case AST_TYPE_VOID:    return Type::getVoidTy(context);
+    case AST_TYPE_POINTER:
+    case AST_TYPE_LIST:
+        return PointerType::get(context, 0);
+    case AST_TYPE_FIXED_SIZE_LIST: {
+        int n = getArrayElementCountFromNode(node);
+        if (n > 0) return createArrayType(getArrayElementTypeFromNode(node), n);
+        return PointerType::get(context, 0);
+    }
+    case AST_TYPE_APP: {
+        std::string baseName;
+        ASTNode *ctor = node->data.type_app.ctor;
+        if (ctor && ctor->type == AST_IDENTIFIER && ctor->data.identifier.name)
+            baseName = ctor->data.identifier.name;
+        if (baseName.empty()) break;
+        if (StructType *st = getStructType(baseName)) return st;
+        if (getStructTemplate(baseName)) {
+            if (Type *inst = instantiateStructType(baseName, node->data.type_app.args))
+                return inst;
+            // instantiation failed (e.g. arity mismatch) — fall through to default
+        }
+        if (vix_is_adt_definition(baseName.c_str()) || baseName == "Option" || baseName == "Result")
+            return PointerType::get(context, 0);
+        break;
+    }
+    case AST_IDENTIFIER: {
+        const char *n = node->data.identifier.name;
+        if (!n) break;
+        std::string s(n);
+        auto git = genericTypeBindings.find(s);
+        if (git != genericTypeBindings.end() && git->second) return git->second;
+        if (s == "ptr")            return PointerType::get(context, 0);
+        if (s == "i8" || s == "u8" || s == "char") return Type::getInt8Ty(context);
+        if (s == "i32")            return Type::getInt32Ty(context);
+        if (s == "i64")            return Type::getInt64Ty(context);
+        if (s == "f32")            return Type::getFloatTy(context);
+        if (s == "f64")            return Type::getDoubleTy(context);
+        if (s == "void")           return Type::getVoidTy(context);
+        if (StructType *st = getStructType(s)) return st;
+        if (getArrayTypeInfo(s))   return PointerType::get(context, 0);
+        break;
+    }
+    default: break;
+    }
+    return Type::getInt32Ty(context);
 }
 
 ValueType TypeHelper::fromLLVMType(Type* type) {

--- a/src/compiler/Types.h
+++ b/src/compiler/Types.h
@@ -6,7 +6,8 @@
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <map>
-#include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <vector>
 #include "../../include/ast.h"
@@ -35,7 +36,9 @@ private:
     std::map<std::string, bool> stringVariables;
     std::map<std::string, llvm::Type*> arrayFieldElementTypes;
     std::map<std::string, llvm::Type*> genericTypeBindings;
-    std::set<std::string> instantiating;
+    std::unordered_set<std::string> instantiating;
+    // Field-index cache: structName → { fieldName → index }
+    std::unordered_map<std::string, std::unordered_map<std::string, int>> fieldIndexCache;
 
     int getTypeRank(ValueType type);
 
@@ -74,6 +77,7 @@ public:
     llvm::Type* getLLVMType(ValueType type);
     ValueType fromLLVMType(llvm::Type* type);
     llvm::Type* getTypeFromTypeNode(ASTNode* node);
+    llvm::Type* typeNodeToLLVM(ASTNode* node);  // unified lookup, shared with Funcs.cpp
     ValueType fromTypeNode(ASTNode* node);
     ValueType getValueTypeFromType(llvm::Type* type);
     std::pair<ValueType, ValueType> promoteTypes(ValueType left, ValueType right);

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -53,6 +53,62 @@ typedef struct {
 static ImplMethodEntry g_impl_methods[512];
 static int g_impl_method_count = 0;
 
+/* ── Tiny inline hash table: name → index lookup ────────────────── */
+#define ADT_HT_SIZE 256
+static int g_adt_ht[ADT_HT_SIZE]; /* maps name hash → def index, -1 = empty */
+
+static unsigned int str_hash(const char *s) {
+    unsigned int h = 5381;
+    while (*s) h = ((h << 5) + h) + (unsigned char)*s++;
+    return h;
+}
+static void adt_ht_insert(const char *name, int idx) {
+    unsigned int h = str_hash(name) & (ADT_HT_SIZE - 1);
+    for (int i = 0; i < ADT_HT_SIZE; i++) {
+        if (g_adt_ht[h] == -1) { g_adt_ht[h] = idx; return; }
+        h = (h + 1) & (ADT_HT_SIZE - 1);
+    }
+    fprintf(stderr, "internal error: ADT hash table full (%d entries)\n", ADT_HT_SIZE);
+}
+static int adt_ht_lookup(const char *name) {
+    if (!name) return -1;
+    unsigned int h = str_hash(name) & (ADT_HT_SIZE - 1);
+    for (int i = 0; i < ADT_HT_SIZE; i++) {
+        int idx = g_adt_ht[h];
+        if (idx == -1) break; /* empty slot → not found */
+        if (g_adt_defs[idx].name && strcmp(g_adt_defs[idx].name, name) == 0)
+            return idx;
+        h = (h + 1) & (ADT_HT_SIZE - 1);
+    }
+    return -1;
+}
+#define IM_HT_SIZE 1024
+static int g_im_ht[IM_HT_SIZE]; /* maps hash to impl_method index, -1 = empty */
+static void im_ht_insert(const char *type_name, const char *method_name, int idx) {
+    char buf[512]; snprintf(buf, sizeof(buf), "%s::%s", type_name, method_name);
+    unsigned int h = str_hash(buf) & (IM_HT_SIZE - 1);
+    for (int i = 0; i < IM_HT_SIZE; i++) {
+        if (g_im_ht[h] == -1) { g_im_ht[h] = idx; return; }
+        h = (h + 1) & (IM_HT_SIZE - 1);
+    }
+    fprintf(stderr, "internal error: Impl method hash table full (%d entries)\n", IM_HT_SIZE);
+}
+static int im_ht_lookup(const char *type_name, const char *method_name) {
+    if (!type_name || !method_name) return -1;
+    char buf[512]; snprintf(buf, sizeof(buf), "%s::%s", type_name, method_name);
+    unsigned int h = str_hash(buf) & (IM_HT_SIZE - 1);
+    for (int i = 0; i < IM_HT_SIZE; i++) {
+        int idx = g_im_ht[h];
+        if (idx == -1) break;
+        if (g_impl_methods[idx].type_name && g_impl_methods[idx].method_name &&
+            strcmp(g_impl_methods[idx].type_name, type_name) == 0 &&
+            strcmp(g_impl_methods[idx].method_name, method_name) == 0)
+            return idx;
+        h = (h + 1) & (IM_HT_SIZE - 1);
+    }
+    return -1;
+}
+
 static void register_impl_method(const char* type_name, const char* method_name, const char* func_name) {
     if (!type_name || !method_name || !func_name) return;
     /* Check for duplicate method within the same type */
@@ -70,6 +126,7 @@ static void register_impl_method(const char* type_name, const char* method_name,
     g_impl_methods[g_impl_method_count].type_name = strdup(type_name);
     g_impl_methods[g_impl_method_count].method_name = strdup(method_name);
     g_impl_methods[g_impl_method_count].func_name = strdup(func_name);
+    im_ht_insert(type_name, method_name, g_impl_method_count);
     g_impl_method_count++;
 }
 
@@ -83,13 +140,8 @@ const char* vix_lookup_impl_method(const char* type_name, const char* method_nam
         normalized[i] = tolower((unsigned char)type_name[i]);
     }
     normalized[len] = '\0';
-    for (int i = 0; i < g_impl_method_count; i++) {
-        if (g_impl_methods[i].type_name && g_impl_methods[i].method_name &&
-            strcmp(g_impl_methods[i].type_name, normalized) == 0 &&
-            strcmp(g_impl_methods[i].method_name, method_name) == 0) {
-            return g_impl_methods[i].func_name;
-        }
-    }
+    int idx = im_ht_lookup(normalized, method_name);
+    if (idx >= 0) return g_impl_methods[idx].func_name;
     return NULL;
 }
 
@@ -129,14 +181,19 @@ void vix_reset_parser_state(void) {
         g_impl_methods[i].func_name = NULL;
     }
     g_impl_method_count = 0;
+    /* Reset hash tables: explicit -1 initialization (portable, no memset trick) */
+    for (int i = 0; i < ADT_HT_SIZE; i++) g_adt_ht[i] = -1;
+    for (int i = 0; i < IM_HT_SIZE; i++) g_im_ht[i] = -1;
 }
 
 static int find_adt_def_index(const char* name) {
     if (!name) return -1;
+    int idx = adt_ht_lookup(name);
+    if (idx >= 0) return idx;
+    // Fallback: linear scan (for entries added before hash table was populated)
     for (int i = 0; i < g_adt_def_count; i++) {
-        if (g_adt_defs[i].name && strcmp(g_adt_defs[i].name, name) == 0) {
+        if (g_adt_defs[i].name && strcmp(g_adt_defs[i].name, name) == 0)
             return i;
-        }
     }
     return -1;
 }
@@ -160,6 +217,7 @@ static void register_adt_definition(const char* name, int generic_arity, ASTNode
     if (idx < 0) {
         if (g_adt_def_count >= (int)(sizeof(g_adt_defs) / sizeof(g_adt_defs[0]))) { g_adt_payload_type_count = 0; return; }
         idx = g_adt_def_count++;
+        adt_ht_insert(name, idx);
         g_adt_defs[idx].name = strdup(name);
         g_adt_defs[idx].ctor_count = 0;
         g_adt_defs[idx].ctors = NULL;

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -613,7 +613,7 @@ void report_simple_error(ErrorLevel level, ErrorType error_type, const char* msg
 }
 
 void adjust_column_to_identifier(const char* name) {
-    if (!name || current_line <= 0) return;
+    if (!name || !*name || current_line <= 0) return;
     char* line = get_line_content(current_line);
     if (!line && current_filename && current_filename[0]) {
         // Fallback: read file directly if source_content is not loaded
@@ -630,7 +630,46 @@ void adjust_column_to_identifier(const char* name) {
         }
     }
     if (!line) return;
-    char* found = strstr(line, name);
+
+    int name_len = (int)strlen(name);
+
+/* Helper macros: is character part of a Vix identifier token? */
+#define is_id_start(c) (((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z') || (c) == '_')
+#define is_id_char(c)  (is_id_start(c) || ((c) >= '0' && (c) <= '9'))
+
+    // Token-aware search: scan for `name` as a complete identifier token.
+    // Start from current_column (if valid), fall back to line start.
+    int scan_start = (current_column > 1) ? (current_column - 1) : 0;
+    if (scan_start >= (int)strlen(line))
+        scan_start = 0;
+
+    for (int pos = scan_start; pos <= (int)strlen(line) - name_len; pos++) {
+        // Does this position match the name?
+        if (strncmp(line + pos, name, (size_t)name_len) != 0)
+            continue;
+
+        // Check left boundary: must be start-of-line or a non-identifier char
+        if (pos > 0 && is_id_char(line[pos - 1]))
+            continue;
+
+        // Check right boundary: must be end-of-line or a non-identifier char
+        int after = pos + name_len;
+        if (line[after] != '\0' && line[after] != '\n' && is_id_char(line[after]))
+            continue;
+
+        // Found a whole-identifier match!
+        current_column = pos + 1;
+        free(line);
+        return;
+    }
+
+#undef is_id_char
+#undef is_id_start
+
+    // Last resort: accept any substring match (better than nothing)
+    char* found = strstr(line + scan_start, name);
+    if (!found && scan_start != 0)
+        found = strstr(line, name);
     if (found) {
         current_column = (int)(found - line) + 1;
     }


### PR DESCRIPTION
…T/impl lookups

- Replace O(n) GlobalVariable linked-list lookups with a local cache; invalidate on new globals.
- Add field index cache in TypeHelper to avoid linear field name search for structs.
- Replace linear ADT and impl method searches with open-addressing hash tables in parser.
- Unify AST type node → LLVM type conversion into typeNodeToLLVM(), deduplicating ~50 lines.
- Extract emitAdtAlloc() helper to reduce code duplication for ADT allocation.
- Split visitProgram into two passes to register generic templates before concrete calls.
- Use std::unordered_set/map instead of std::set/map for internal lookups.
- Fix adjust_column_to_identifier to token-aware whole-identifier matching to prevent false positives.
- Remove dead #ifdef HAVE_PARSER_TAB_H block in ast.c.